### PR TITLE
Add getter for S3 API endpoint URL

### DIFF
--- a/b2/b2.go
+++ b/b2/b2.go
@@ -408,6 +408,10 @@ func (b *Bucket) BaseURL() string {
 	return b.b.baseURL()
 }
 
+func (b *Bucket) S3URL() string {
+	return b.b.s3URL()
+}
+
 // Name returns the bucket's name.
 func (b *Bucket) Name() string {
 	return b.b.name()

--- a/b2/backend.go
+++ b/b2/backend.go
@@ -58,6 +58,7 @@ type beBucketInterface interface {
 	hideFile(context.Context, string) (beFileInterface, error)
 	getDownloadAuthorization(context.Context, string, time.Duration, string) (string, error)
 	baseURL() string
+	s3URL() string
 	file(string, string) beFileInterface
 }
 
@@ -493,6 +494,10 @@ func (b *beBucket) getDownloadAuthorization(ctx context.Context, p string, v tim
 
 func (b *beBucket) baseURL() string {
 	return b.b2bucket.baseURL()
+}
+
+func (b *beBucket) s3URL() string {
+	return b.b2bucket.s3URL()
 }
 
 func (b *beBucket) file(id, name string) beFileInterface {

--- a/b2/baseline.go
+++ b/b2/baseline.go
@@ -54,6 +54,7 @@ type b2BucketInterface interface {
 	hideFile(context.Context, string) (b2FileInterface, error)
 	getDownloadAuthorization(context.Context, string, time.Duration, string) (string, error)
 	baseURL() string
+	s3URL() string
 	file(string, string) b2FileInterface
 }
 
@@ -397,6 +398,10 @@ func (b *b2Bucket) getDownloadAuthorization(ctx context.Context, p string, v tim
 
 func (b *b2Bucket) baseURL() string {
 	return b.b.BaseURL()
+}
+
+func (b *b2Bucket) s3URL() string {
+	return b.b.S3URL()
 }
 
 func (b *b2Bucket) file(id, name string) b2FileInterface { return &b2File{b.b.File(id, name)} }

--- a/base/base.go
+++ b/base/base.go
@@ -277,6 +277,7 @@ type B2 struct {
 	accountID   string
 	authToken   string
 	apiURI      string
+	s3URI       string
 	downloadURI string
 	minPartSize int
 	opts        *b2Options
@@ -451,6 +452,7 @@ func AuthorizeAccount(ctx context.Context, account, key string, opts ...AuthOpti
 		accountID:   b2resp.AccountID,
 		authToken:   b2resp.AuthToken,
 		apiURI:      b2resp.URI,
+		s3URI:       b2resp.S3URI,
 		downloadURI: b2resp.DownloadURI,
 		minPartSize: b2resp.PartSize,
 		bucket:      b2resp.Allowed.Bucket,
@@ -635,6 +637,11 @@ func (b *Bucket) Update(ctx context.Context) (*Bucket, error) {
 // BaseURL returns the base part of the download URLs.
 func (b *Bucket) BaseURL() string {
 	return b.b2.downloadURI
+}
+
+// S3URL returns the base URL for S3-compatible API calls.
+func (b *Bucket) S3URL() string {
+	return b.b2.s3URI
 }
 
 // ListBuckets wraps b2_list_buckets.  If name is non-empty, only that bucket

--- a/internal/b2types/b2types.go
+++ b/internal/b2types/b2types.go
@@ -32,6 +32,7 @@ type AuthorizeAccountResponse struct {
 	AccountID      string    `json:"accountId"`
 	AuthToken      string    `json:"authorizationToken"`
 	URI            string    `json:"apiUrl"`
+	S3URI          string    `json:"s3ApiUrl"`
 	DownloadURI    string    `json:"downloadUrl"`
 	MinPartSize    int       `json:"minimumPartSize"`
 	PartSize       int       `json:"recommendedPartSize"`


### PR DESCRIPTION
The definition of the `b2-authorize-account` API at https://www.backblaze.com/apidocs/b2-authorize-account includes a description of the s3ApiUrl field:

> **s3ApiUrl** string
> 
> The base URL to use for all API calls using the [S3 compatible API](https://www.backblaze.com/apidocs/introduction-to-the-s3-compatible-api).
> 
> EXAMPLE `https://s3.us-west-NNN.backblazeb2.com`

This field is useful in certain circumstances, such as automatic configuration of settings for a client to use to access the S3 API. However, it is not parsed by the current implementation of `blazer`, which makes this hard to do.

This pull request exposes the S3 API URL in the same way as the Download URL (Base URL). I am not familiar with the details of the implementation of `blazer`, so please let me know if this is not the appropriate way to solve this problem, or if I need to change something about this pull request. The [contributing guidelines](https://github.com/Backblaze/blazer/blob/efa10c0fffe98ce85c0a927a13249cc695a4f8e5/CONTRIBUTING.md) were not very detailed.