### PR TITLE
feat(client): update b2_create_bucket and b2_update_bucket to use v3 api which allows setting new config including bucket encryption

### DIFF
--- a/b2/b2.go
+++ b/b2/b2.go
@@ -218,7 +218,7 @@ type BucketAttrs struct {
 	// If specified, the existing default bucket retention settings will be replaced with the new settings. If not specified,
 	// the setting will remain unchanged. Setting the value requires the writeBucketRetentions capability and that the bucket is Object Lock-enabled.
 	// Object Lock: https://www.backblaze.com/docs/cloud-storage-enable-object-lock-with-the-native-api.
-	DefaultRetention string
+	DefaultRetention *Retention
 	// The default server-side encryption settings for this bucket. See Server-Side Encryption settings for new files uploaded to this bucket.
 	// This field is filtered based on application key capabilities; readBucketEncryption capability is required to access the value.
 	// See Server-Side Encryption for an overview and the parameter structure. If specified, the existing default bucket encryption settings will
@@ -255,8 +255,8 @@ func DefaultServerSideEncryption() *ServerSideEncryption {
 }
 
 type ServerSideEncryption struct {
-	Mode      string `json:"mode"`
-	Algorithm string `json:"algorithm"`
+	Mode      string
+	Algorithm string
 }
 
 type CORSRule struct {
@@ -266,6 +266,16 @@ type CORSRule struct {
 	AllowedOperations []string
 	ExposeHeaders     []string
 	MaxAgeSeconds     int
+}
+
+type Retention struct {
+	Mode   string
+	Period *RetentionPeriod
+}
+
+type RetentionPeriod struct {
+	Duration int
+	Unit     string
 }
 
 type ReplicationConfiguration struct {

--- a/b2/baseline.go
+++ b/b2/baseline.go
@@ -287,7 +287,7 @@ func (b *b2Bucket) updateBucket(ctx context.Context, attrs *BucketAttrs) error {
 
 	b.b.FileLockEnabled = attrs.FileLockEnabled
 
-	if b.b.ReplicationConfig != nil {
+	if b.b.ReplicationConfiguration != nil {
 		asRepSource := b2types.AsReplicationSource{
 			SourceApplicationKeyID: attrs.ReplicationConfig.AsReplicationSource.SourceApplicationKeyID,
 			ReplicationRules:       make([]b2types.ReplicationRules, len(attrs.ReplicationConfig.AsReplicationSource.ReplicationRules)),
@@ -304,8 +304,8 @@ func (b *b2Bucket) updateBucket(ctx context.Context, attrs *BucketAttrs) error {
 			}
 		}
 
-		b.b.ReplicationConfig = &b2types.ReplicationConfiguration{
-			AsReplicationSource: asRepSource,
+		b.b.ReplicationConfiguration = &b2types.ReplicationConfiguration{
+			AsReplicationSource: &asRepSource,
 		}
 	}
 

--- a/b2/baseline.go
+++ b/b2/baseline.go
@@ -268,7 +268,15 @@ func (b *b2Bucket) updateBucket(ctx context.Context, attrs *BucketAttrs) error {
 		b.b.CORSRules = rules
 	}
 
-	b.b.DefaultRetention = attrs.DefaultRetention
+	if attrs.DefaultRetention != nil {
+		b.b.DefaultRetention = &b2types.Retention{
+			Mode: attrs.DefaultRetention.Mode,
+			Period: &b2types.RetentionPeriod{
+				Duration: attrs.DefaultRetention.Period.Duration,
+				Unit:     attrs.DefaultRetention.Period.Unit,
+			},
+		}
+	}
 
 	if attrs.DefaultServerSideEncryption != nil {
 		b.b.DefaultServerSideEncryption = &b2types.ServerSideEncryption{

--- a/base/base.go
+++ b/base/base.go
@@ -590,7 +590,7 @@ type Bucket struct {
 	b2             *B2
 
 	CORSRules                   []b2types.CORSRule
-	DefaultRetention            string
+	DefaultRetention            *b2types.Retention
 	DefaultServerSideEncryption *b2types.ServerSideEncryption
 	FileLockEnabled             bool
 	ReplicationConfig           *b2types.ReplicationConfiguration
@@ -668,7 +668,7 @@ func (b *B2) ListBuckets(ctx context.Context, name string) ([]*Bucket, error) {
 	headers := map[string]string{
 		"Authorization": b.authToken,
 	}
-	if err := b.opts.makeRequest(ctx, "b2_list_buckets", "POST", b.apiURI+b2types.V1api+"b2_list_buckets", b2req, b2resp, headers, nil); err != nil {
+	if err := b.opts.makeRequest(ctx, "b2_list_buckets", "POST", b.apiURI+b2types.V3api+"b2_list_buckets", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	var buckets []*Bucket

--- a/base/base.go
+++ b/base/base.go
@@ -546,7 +546,7 @@ func (b *B2) CreateBucket(ctx context.Context, name, btype string, info map[stri
 	headers := map[string]string{
 		"Authorization": b.authToken,
 	}
-	if err := b.opts.makeRequest(ctx, "b2_create_bucket", "POST", b.apiURI+b2types.V1api+"b2_create_bucket", b2req, b2resp, headers, nil); err != nil {
+	if err := b.opts.makeRequest(ctx, "b2_create_bucket", "POST", b.apiURI+b2types.V3api+"b2_create_bucket", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	var respRules []LifecycleRule
@@ -588,6 +588,12 @@ type Bucket struct {
 	ID             string
 	rev            int
 	b2             *B2
+
+	CORSRules                   []b2types.CORSRule
+	DefaultRetention            string
+	DefaultServerSideEncryption *b2types.ServerSideEncryption
+	FileLockEnabled             bool
+	ReplicationConfig           *b2types.ReplicationConfiguration
 }
 
 // Update wraps b2_update_bucket.
@@ -608,12 +614,18 @@ func (b *Bucket) Update(ctx context.Context) (*Bucket, error) {
 		Info:           b.Info,
 		LifecycleRules: rules,
 		IfRevisionIs:   b.rev,
+
+		CORSRules:                   b.CORSRules,
+		DefaultRetention:            b.DefaultRetention,
+		DefaultServerSideEncryption: b.DefaultServerSideEncryption,
+		FileLockEnabled:             b.FileLockEnabled,
+		ReplicationConfig:           b.ReplicationConfig,
 	}
 	headers := map[string]string{
 		"Authorization": b.b2.authToken,
 	}
 	b2resp := &b2types.UpdateBucketResponse{}
-	if err := b.b2.opts.makeRequest(ctx, "b2_update_bucket", "POST", b.b2.apiURI+b2types.V1api+"b2_update_bucket", b2req, b2resp, headers, nil); err != nil {
+	if err := b.b2.opts.makeRequest(ctx, "b2_update_bucket", "POST", b.b2.apiURI+b2types.V3api+"b2_update_bucket", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	var respRules []LifecycleRule

--- a/base/integration_test.go
+++ b/base/integration_test.go
@@ -140,7 +140,7 @@ func TestStorage(t *testing.T) {
 		return
 	}
 
-	// b2_update_bucket filelock configuration
+	// b2_update_bucket defaultRetention configuration
 	bucket.DefaultRetention = &b2types.Retention{
 		Mode: "governance",
 		Period: &b2types.RetentionPeriod{
@@ -159,6 +159,7 @@ func TestStorage(t *testing.T) {
 		return
 	}
 
+	// b2_update_bucket corsRules configuration
 	bucket.CORSRules = []b2types.CORSRule{
 		{
 			Name:          "test",
@@ -188,6 +189,7 @@ func TestStorage(t *testing.T) {
 		return
 	}
 
+	// b2_update_bucket replicationConfiguration
 	bucket.ReplicationConfig = &b2types.ReplicationConfiguration{
 		AsReplicationSource: b2types.AsReplicationSource{
 			SourceApplicationKeyID: "123456",

--- a/base/strings_test.go
+++ b/base/strings_test.go
@@ -1,7 +1,6 @@
 package base
 
 import (
-	"fmt"
 	"testing"
 )
 
@@ -34,19 +33,17 @@ func TestEncodeDecode(t *testing.T) {
 	}
 }
 
-// hook for go-fuzz: https://github.com/dvyukov/go-fuzz
-func Fuzz(data []byte) int {
-	orig := string(data)
-	escaped := escape(orig)
+func Fuzz(f *testing.F) {
+	f.Fuzz(func(t *testing.T, orig string) {
+		escaped := escape(orig)
 
-	unescaped, err := unescape(escaped)
-	if err != nil {
-		return 0
-	}
+		unescaped, err := unescape(escaped)
+		if err != nil {
+			t.Errorf("Can't unescape escaped string %q", escaped)
+		}
 
-	if unescaped != orig {
-		panic(fmt.Sprintf("unescaped: \"%#v\", != orig: \"%#v\"", unescaped, orig))
-	}
-
-	return 1
+		if unescaped != orig {
+			t.Errorf("Before: %q, after: %q", orig, unescaped)
+		}
+	})
 }

--- a/internal/b2types/b2types.go
+++ b/internal/b2types/b2types.go
@@ -93,9 +93,10 @@ type DeleteBucketRequest struct {
 }
 
 type ListBucketsRequest struct {
-	AccountID string `json:"accountId"`
-	Bucket    string `json:"bucketId,omitempty"`
-	Name      string `json:"bucketName,omitempty"`
+	AccountID   string   `json:"accountId"`
+	Bucket      string   `json:"bucketId,omitempty"`
+	Name        string   `json:"bucketName,omitempty"`
+	BucketTypes []string `json:"bucketTypes,omitempty"`
 }
 
 type ListBucketsResponse struct {
@@ -111,7 +112,7 @@ type UpdateBucketRequest struct {
 	IfRevisionIs   int               `json:"ifRevisionIs,omitempty"`
 
 	CORSRules                   []CORSRule                `json:"corsRules,omitempty"`
-	DefaultRetention            string                    `json:"defaultRetention,omitempty"`
+	DefaultRetention            *Retention                `json:"defaultRetention,omitempty"`
 	DefaultServerSideEncryption *ServerSideEncryption     `json:"defaultServerSideEncryption,omitempty"`
 	FileLockEnabled             bool                      `json:"fileLockEnabled,omitempty"`
 	ReplicationConfig           *ReplicationConfiguration `json:"replicationConfig,omitempty"`
@@ -310,6 +311,16 @@ type ListKeysResponse struct {
 type ServerSideEncryption struct {
 	Mode      string `json:"mode"`
 	Algorithm string `json:"algorithm"`
+}
+
+type Retention struct {
+	Mode   string           `json:"mode,omitempty"`
+	Period *RetentionPeriod `json:"period,omitempty"`
+}
+
+type RetentionPeriod struct {
+	Duration int    `json:"duration,omitempty"`
+	Unit     string `json:"unit,omitempty"`
 }
 
 type CORSRule struct {

--- a/internal/b2types/b2types.go
+++ b/internal/b2types/b2types.go
@@ -69,11 +69,11 @@ type CreateBucketResponse struct {
 	LifecycleRules []LifecycleRule   `json:"lifecycleRules"`
 	Revision       int               `json:"revision"`
 
-	CORSRules                   []CORSRule                `json:"corsRules,omitempty"`
-	DefaultRetention            string                    `json:"defaultRetention,omitempty"`
-	DefaultServerSideEncryption *ServerSideEncryption     `json:"defaultServerSideEncryption,omitempty"`
-	FileLockConfig              *FileLockConfiguration    `json:"fileLockConfiguration,omitempty"`
-	ReplicationConfig           *ReplicationConfiguration `json:"replicationConfig,omitempty"`
+	CORSRules                   []CORSRule                        `json:"corsRules,omitempty"`
+	DefaultRetention            string                            `json:"defaultRetention,omitempty"`
+	DefaultServerSideEncryption *ServerSideEncryption             `json:"defaultServerSideEncryption,omitempty"`
+	FileLockConfig              *FileLockConfiguration            `json:"fileLockConfiguration,omitempty"`
+	ReplicationConfiguration    *ReplicationConfigurationResponse `json:"replicationConfiguration,omitempty"`
 }
 
 type FileLockConfiguration struct {
@@ -81,7 +81,10 @@ type FileLockConfiguration struct {
 	Val                      struct {
 		DefaultRetention struct {
 			Mode   *string `json:"mode"`
-			Period *string `json:"period"`
+			Period struct {
+				Duration int     `json:"duration"`
+				Unit     *string `json:"unit"`
+			} `json:"period"`
 		} `json:"defaultRetention"`
 		IsFileLockEnabled bool `json:"isFileLockEnabled"`
 	} `json:"value"`
@@ -115,7 +118,7 @@ type UpdateBucketRequest struct {
 	DefaultRetention            *Retention                `json:"defaultRetention,omitempty"`
 	DefaultServerSideEncryption *ServerSideEncryption     `json:"defaultServerSideEncryption,omitempty"`
 	FileLockEnabled             bool                      `json:"fileLockEnabled,omitempty"`
-	ReplicationConfig           *ReplicationConfiguration `json:"replicationConfig,omitempty"`
+	ReplicationConfiguration    *ReplicationConfiguration `json:"replicationConfiguration,omitempty"`
 }
 
 type UpdateBucketResponse CreateBucketResponse
@@ -332,13 +335,18 @@ type CORSRule struct {
 	MaxAgeSeconds     int      `json:"maxAgeSeconds,omitempty"`
 }
 
+type ReplicationConfigurationResponse struct {
+	IsClientAuthorizedToRead bool                      `json:"isClientAuthorizedToRead,omitempty"`
+	Value                    *ReplicationConfiguration `json:"value,omitempty"`
+}
+
 type ReplicationConfiguration struct {
-	AsReplicationSource AsReplicationSource `json:"asReplicationSource"`
+	AsReplicationSource *AsReplicationSource `json:"asReplicationSource,omitempty"`
 }
 
 type AsReplicationSource struct {
-	ReplicationRules       []ReplicationRules `json:"replicationRules"`
-	SourceApplicationKeyID string             `json:"sourceApplicationKeyId"`
+	ReplicationRules       []ReplicationRules `json:"replicationRules,omitempty"`
+	SourceApplicationKeyID string             `json:"sourceApplicationKeyId,omitempty"`
 }
 
 type ReplicationRules struct {

--- a/internal/b2types/b2types.go
+++ b/internal/b2types/b2types.go
@@ -20,6 +20,7 @@ package b2types
 
 const (
 	V1api = "/b2api/v1/"
+	V3api = "/b2api/v3/"
 )
 
 type ErrorMessage struct {
@@ -67,6 +68,23 @@ type CreateBucketResponse struct {
 	Info           map[string]string `json:"bucketInfo"`
 	LifecycleRules []LifecycleRule   `json:"lifecycleRules"`
 	Revision       int               `json:"revision"`
+
+	CORSRules                   []CORSRule                `json:"corsRules,omitempty"`
+	DefaultRetention            string                    `json:"defaultRetention,omitempty"`
+	DefaultServerSideEncryption *ServerSideEncryption     `json:"defaultServerSideEncryption,omitempty"`
+	FileLockConfig              *FileLockConfiguration    `json:"fileLockConfiguration,omitempty"`
+	ReplicationConfig           *ReplicationConfiguration `json:"replicationConfig,omitempty"`
+}
+
+type FileLockConfiguration struct {
+	IsClientAuthorizedToRead bool `json:"isClientAuthorizedToRead"`
+	Val                      struct {
+		DefaultRetention struct {
+			Mode   *string `json:"mode"`
+			Period *string `json:"period"`
+		} `json:"defaultRetention"`
+		IsFileLockEnabled bool `json:"isFileLockEnabled"`
+	} `json:"value"`
 }
 
 type DeleteBucketRequest struct {
@@ -91,6 +109,12 @@ type UpdateBucketRequest struct {
 	Info           map[string]string `json:"bucketInfo,omitempty"`
 	LifecycleRules []LifecycleRule   `json:"lifecycleRules,omitempty"`
 	IfRevisionIs   int               `json:"ifRevisionIs,omitempty"`
+
+	CORSRules                   []CORSRule                `json:"corsRules,omitempty"`
+	DefaultRetention            string                    `json:"defaultRetention,omitempty"`
+	DefaultServerSideEncryption *ServerSideEncryption     `json:"defaultServerSideEncryption,omitempty"`
+	FileLockEnabled             bool                      `json:"fileLockEnabled,omitempty"`
+	ReplicationConfig           *ReplicationConfiguration `json:"replicationConfig,omitempty"`
 }
 
 type UpdateBucketResponse CreateBucketResponse
@@ -281,4 +305,36 @@ type ListKeysRequest struct {
 type ListKeysResponse struct {
 	Keys []Key  `json:"keys"`
 	Next string `json:"nextApplicationKeyId"`
+}
+
+type ServerSideEncryption struct {
+	Mode      string `json:"mode"`
+	Algorithm string `json:"algorithm"`
+}
+
+type CORSRule struct {
+	Name              string   `json:"corsRuleName,omitempty"`
+	AllowedOrigins    []string `json:"allowedOrigins,omitempty"`
+	AllowedHeaders    []string `json:"allowedHeaders,omitempty"`
+	AllowedOperations []string `json:"allowedOperations,omitempty"`
+	ExposeHeaders     []string `json:"exposeHeaders,omitempty"`
+	MaxAgeSeconds     int      `json:"maxAgeSeconds,omitempty"`
+}
+
+type ReplicationConfiguration struct {
+	AsReplicationSource AsReplicationSource `json:"asReplicationSource"`
+}
+
+type AsReplicationSource struct {
+	ReplicationRules       []ReplicationRules `json:"replicationRules"`
+	SourceApplicationKeyID string             `json:"sourceApplicationKeyId"`
+}
+
+type ReplicationRules struct {
+	DestinationBucketID  string `json:"destinationBucketId"`
+	FileNamePrefix       string `json:"fileNamePrefix"`
+	IncludeExistingFiles bool   `json:"includeExistingFiles"`
+	IsEnabled            bool   `json:"isEnabled"`
+	Priority             int    `json:"priority"`
+	ReplicationRuleName  string `json:"replicationRuleName"`
 }


### PR DESCRIPTION
# Summary
This PR updates the API calls to `b2_create_bucket` and `b2_update_bucket` to use the v3 API, which allows setting some important configuration like encryption.

Note: I noticed that structs are redefined between the layers and then translated over, not sure if this was by design but I did not follow this pattern. If this pattern should be followed, please let me know and I can just copy and paste the structs in a few more places.

Thanks!
