### PR TITLE
Typo in example, gofmt pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ ctx := context.Background()
 // b2_authorize_account
 b2, err := b2.NewClient(ctx, id, key)
 if err != nil {
-	log.Fatalln(e)
+	log.Fatalln(err)
 }
 
 buckets, err := b2.ListBuckets(ctx)
 if err != nil {
-	log.Fatalln(e)
+	log.Fatalln(err)
 }
 ```
 

--- a/b2/integration_test.go
+++ b/b2/integration_test.go
@@ -303,19 +303,19 @@ func TestAttrs(t *testing.T) {
 	defer done()
 
 	attrlist := []*Attrs{
-		&Attrs{
+		{
 			ContentType: "jpeg/stream",
 			Info: map[string]string{
 				"one": "a",
 				"two": "b",
 			},
 		},
-		&Attrs{
+		{
 			ContentType:  "application/MAGICFACE",
 			LastModified: time.Unix(1464370149, 142000000),
 			Info:         map[string]string{}, // can't be nil
 		},
-		&Attrs{
+		{
 			ContentType: "arbitrarystring",
 			Info: map[string]string{
 				"spaces":  "string with spaces",

--- a/internal/b2assets/b2assets.go
+++ b/internal/b2assets/b2assets.go
@@ -147,11 +147,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error
@@ -182,9 +184,10 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
-	"data": &bintree{nil, map[string]*bintree{
-		"status.html": &bintree{dataStatusHtml, map[string]*bintree{}},
+	"data": {nil, map[string]*bintree{
+		"status.html": {dataStatusHtml, map[string]*bintree{}},
 	}},
 }}
 
@@ -234,4 +237,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-


### PR DESCRIPTION
First example have a typo, it assigns to `err` but tries to return `e` as error that does not exist.

I've also ran gofmt pass