### PR TITLE
Support v4 Multi-Bucket Application Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `b2_authorize_account` and the other general API calls now target the
-  B2 Native API v4. The `apiInfo.storageApi` block is parsed from the
-  v4 response shape: `bucketIds` and `bucketNames` arrays in place of
-  the singular `bucketId` and `bucketName`. This allows the client to
-  authenticate with Multi-Bucket Application Keys, which the v3
-  endpoint does not accept.
+  B2 Native API v4. A restricted key's scope is parsed from the v4
+  response shape under `apiInfo.storageApi.allowed`: a `buckets` array of
+  `{id, name}` objects in place of the singular `bucketId`/`bucketName`,
+  plus `namePrefix`. This allows the client to authenticate with
+  Multi-Bucket Application Keys, which the v3 endpoint does not accept.
 - `(*base.B2).CreateKey` and `(*b2.Bucket).CreateKey` continue to
   target the v3 `b2_create_key` endpoint and produce legacy
   single-bucket keys. This preserves wire-level compatibility with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `(*base.B2).CreateKeyMultiBucket` and the `b2.BucketIDs` `KeyOption`
-  for creating Multi-Bucket Application Keys via `(*b2.Client).CreateKey`.
-  Multi-bucket keys are created against the B2 Native API v4
-  `b2_create_key` endpoint.
+- `(*base.B2).CreateKeyMultiBucket` and the `b2.BucketIDs` `KeyOption` for creating Multi-Bucket Application Keys via `(*b2.Client).CreateKey`.
 
 ### Changed
 
-- `b2_authorize_account` and the other general API calls now target the
-  B2 Native API v4. A restricted key's scope is parsed from the v4
-  response shape under `apiInfo.storageApi.allowed`: a `buckets` array of
-  `{id, name}` objects in place of the singular `bucketId`/`bucketName`,
-  plus `namePrefix`. This allows the client to authenticate with
-  Multi-Bucket Application Keys, which the v3 endpoint does not accept.
-- `(*base.B2).CreateKey` and `(*b2.Bucket).CreateKey` continue to
-  target the v3 `b2_create_key` endpoint and produce legacy
-  single-bucket keys. This preserves wire-level compatibility with
-  clients that have not adopted v4.
+- `b2_authorize_account` and the other general API calls now target the B2 Native API v4. `(*base.B2).CreateKey` and `(*b2.Bucket).CreateKey` continue to target the v3 `b2_create_key` endpoint and produce legacy single-bucket keys.
 
 ## [0.7.2] - 2025-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing at present
+### Added
+
+- `(*base.B2).CreateKeyMultiBucket` and the `b2.BucketIDs` `KeyOption`
+  for creating Multi-Bucket Application Keys via `(*b2.Client).CreateKey`.
+  Multi-bucket keys are created against the B2 Native API v4
+  `b2_create_key` endpoint.
+
+### Changed
+
+- `b2_authorize_account` and the other general API calls now target the
+  B2 Native API v4. The `apiInfo.storageApi` block is parsed from the
+  v4 response shape: `bucketIds` and `bucketNames` arrays in place of
+  the singular `bucketId` and `bucketName`. This allows the client to
+  authenticate with Multi-Bucket Application Keys, which the v3
+  endpoint does not accept.
+- `(*base.B2).CreateKey` and `(*b2.Bucket).CreateKey` continue to
+  target the v3 `b2_create_key` endpoint and produce legacy
+  single-bucket keys. This preserves wire-level compatibility with
+  clients that have not adopted v4.
 
 ## [0.7.2] - 2025-01-23
 

--- a/b2/b2_test.go
+++ b/b2/b2_test.go
@@ -1494,6 +1494,19 @@ func TestCreateKeyDispatch(t *testing.T) {
 		}
 	})
 
+	t.Run("ClientCreateKey with one BucketID routes to createKey", func(t *testing.T) {
+		client, root := newClient()
+		if _, err := client.CreateKey(ctx, "kn", BucketIDs("buck-a")); err != nil {
+			t.Fatalf("CreateKey: %v", err)
+		}
+		if root.lastKeyMethod != "createKey" {
+			t.Errorf("lastKeyMethod = %q, want %q", root.lastKeyMethod, "createKey")
+		}
+		if root.lastKeyBucketID != "buck-a" {
+			t.Errorf("lastKeyBucketID = %q, want %q", root.lastKeyBucketID, "buck-a")
+		}
+	})
+
 	t.Run("ClientCreateKey with BucketIDs routes to createKeyMultiBucket", func(t *testing.T) {
 		client, root := newClient()
 		if _, err := client.CreateKey(ctx, "kn", BucketIDs("buck-a", "buck-b"), Prefix("p/")); err != nil {

--- a/b2/b2_test.go
+++ b/b2/b2_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -69,6 +70,11 @@ type testRoot struct {
 	errs      *errCont
 	auths     int
 	bucketMap map[string]map[string]string
+
+	lastKeyMethod    string
+	lastKeyBucketID  string
+	lastKeyBucketIDs []string
+	lastKeyPrefix    string
 }
 
 func (t *testRoot) authorizeAccount(context.Context, string, string, clientOptions) error {
@@ -133,7 +139,16 @@ func (t *testRoot) reupload(err error) bool {
 	return e.reupload
 }
 
-func (t *testRoot) createKey(context.Context, string, []string, time.Duration, string, string) (b2KeyInterface, error) {
+func (t *testRoot) createKey(_ context.Context, _ string, _ []string, _ time.Duration, bucketID, prefix string) (b2KeyInterface, error) {
+	t.lastKeyMethod = "createKey"
+	t.lastKeyBucketID = bucketID
+	t.lastKeyPrefix = prefix
+	return nil, nil
+}
+func (t *testRoot) createKeyMultiBucket(_ context.Context, _ string, _ []string, _ time.Duration, bucketIDs []string, prefix string) (b2KeyInterface, error) {
+	t.lastKeyMethod = "createKeyMultiBucket"
+	t.lastKeyBucketIDs = bucketIDs
+	t.lastKeyPrefix = prefix
 	return nil, nil
 }
 func (t *testRoot) listKeys(context.Context, int, string) ([]b2KeyInterface, string, error) {
@@ -1453,4 +1468,73 @@ func readFile(ctx context.Context, obj *Object, sha string, chunk, concur int) e
 		return fmt.Errorf("bad hash: got %s, want %s", rsha, sha)
 	}
 	return nil
+}
+
+func TestCreateKeyDispatch(t *testing.T) {
+	ctx := context.Background()
+
+	newClient := func() (*Client, *testRoot) {
+		root := &testRoot{
+			bucketMap: make(map[string]map[string]string),
+			errs:      &errCont{},
+		}
+		return &Client{backend: &beRoot{b2i: root}}, root
+	}
+
+	t.Run("ClientCreateKey routes to createKey", func(t *testing.T) {
+		client, root := newClient()
+		if _, err := client.CreateKey(ctx, "kn"); err != nil {
+			t.Fatalf("CreateKey: %v", err)
+		}
+		if root.lastKeyMethod != "createKey" {
+			t.Errorf("lastKeyMethod = %q, want %q", root.lastKeyMethod, "createKey")
+		}
+		if root.lastKeyBucketID != "" {
+			t.Errorf("lastKeyBucketID = %q, want empty", root.lastKeyBucketID)
+		}
+	})
+
+	t.Run("ClientCreateKey with BucketIDs routes to createKeyMultiBucket", func(t *testing.T) {
+		client, root := newClient()
+		if _, err := client.CreateKey(ctx, "kn", BucketIDs("buck-a", "buck-b"), Prefix("p/")); err != nil {
+			t.Fatalf("CreateKey: %v", err)
+		}
+		if root.lastKeyMethod != "createKeyMultiBucket" {
+			t.Errorf("lastKeyMethod = %q, want %q", root.lastKeyMethod, "createKeyMultiBucket")
+		}
+		if got, want := root.lastKeyBucketIDs, []string{"buck-a", "buck-b"}; !reflect.DeepEqual(got, want) {
+			t.Errorf("lastKeyBucketIDs = %v, want %v", got, want)
+		}
+		if root.lastKeyPrefix != "p/" {
+			t.Errorf("lastKeyPrefix = %q, want %q", root.lastKeyPrefix, "p/")
+		}
+	})
+
+	t.Run("BucketCreateKey routes to createKey", func(t *testing.T) {
+		// testBucket.id() returns "" so we can't assert the propagated
+		// bucket id here; the important invariant is that Bucket.CreateKey
+		// never takes the multi-bucket path.
+		client, root := newClient()
+		bucket, err := client.NewBucket(ctx, "b", &BucketAttrs{Type: Private})
+		if err != nil {
+			t.Fatalf("NewBucket: %v", err)
+		}
+		if _, err := bucket.CreateKey(ctx, "kn", Capabilities("listFiles")); err != nil {
+			t.Fatalf("Bucket.CreateKey: %v", err)
+		}
+		if root.lastKeyMethod != "createKey" {
+			t.Errorf("lastKeyMethod = %q, want %q", root.lastKeyMethod, "createKey")
+		}
+	})
+
+	t.Run("BucketCreateKey rejects BucketIDs", func(t *testing.T) {
+		client, _ := newClient()
+		bucket, err := client.NewBucket(ctx, "b2", &BucketAttrs{Type: Private})
+		if err != nil {
+			t.Fatalf("NewBucket: %v", err)
+		}
+		if _, err := bucket.CreateKey(ctx, "kn", BucketIDs("x")); err == nil {
+			t.Errorf("Bucket.CreateKey with BucketIDs: want error, got nil")
+		}
+	})
 }

--- a/b2/b2_test.go
+++ b/b2/b2_test.go
@@ -1511,9 +1511,8 @@ func TestCreateKeyDispatch(t *testing.T) {
 	})
 
 	t.Run("BucketCreateKey routes to createKey", func(t *testing.T) {
-		// testBucket.id() returns "" so we can't assert the propagated
-		// bucket id here; the important invariant is that Bucket.CreateKey
-		// never takes the multi-bucket path.
+		// testBucket.id() is "", so we only assert that Bucket.CreateKey
+		// avoids the multi-bucket path, not the propagated bucket id.
 		client, root := newClient()
 		bucket, err := client.NewBucket(ctx, "b", &BucketAttrs{Type: Private})
 		if err != nil {

--- a/b2/backend.go
+++ b/b2/backend.go
@@ -36,6 +36,7 @@ type beRootInterface interface {
 	createBucket(ctx context.Context, name, btype string, info map[string]string, rules []LifecycleRule) (beBucketInterface, error)
 	listBuckets(context.Context, string, ...string) ([]beBucketInterface, error)
 	createKey(context.Context, string, []string, time.Duration, string, string) (beKeyInterface, error)
+	createKeyMultiBucket(context.Context, string, []string, time.Duration, []string, string) (beKeyInterface, error)
 	listKeys(context.Context, int, string) ([]beKeyInterface, string, error)
 }
 
@@ -244,6 +245,28 @@ func (r *beRoot) createKey(ctx context.Context, name string, caps []string, vali
 	f := func() error {
 		g := func() error {
 			got, err := r.b2i.createKey(ctx, name, caps, valid, bucketID, prefix)
+			if err != nil {
+				return err
+			}
+			k = &beKey{
+				b2i: r,
+				k:   got,
+			}
+			return nil
+		}
+		return withReauth(ctx, r, g)
+	}
+	if err := withBackoff(ctx, r, f); err != nil {
+		return nil, err
+	}
+	return k, nil
+}
+
+func (r *beRoot) createKeyMultiBucket(ctx context.Context, name string, caps []string, valid time.Duration, bucketIDs []string, prefix string) (beKeyInterface, error) {
+	var k *beKey
+	f := func() error {
+		g := func() error {
+			got, err := r.b2i.createKeyMultiBucket(ctx, name, caps, valid, bucketIDs, prefix)
 			if err != nil {
 				return err
 			}

--- a/b2/baseline.go
+++ b/b2/baseline.go
@@ -38,6 +38,7 @@ type b2RootInterface interface {
 	createBucket(context.Context, string, string, map[string]string, []LifecycleRule) (b2BucketInterface, error)
 	listBuckets(context.Context, string, ...string) ([]b2BucketInterface, error)
 	createKey(context.Context, string, []string, time.Duration, string, string) (b2KeyInterface, error)
+	createKeyMultiBucket(context.Context, string, []string, time.Duration, []string, string) (b2KeyInterface, error)
 	listKeys(context.Context, int, string) ([]b2KeyInterface, string, error)
 }
 
@@ -335,6 +336,14 @@ func (b *b2Bucket) updateBucket(ctx context.Context, attrs *BucketAttrs) error {
 
 func (b *b2Root) createKey(ctx context.Context, name string, caps []string, valid time.Duration, bucketID string, prefix string) (b2KeyInterface, error) {
 	k, err := b.b.CreateKey(ctx, name, caps, valid, bucketID, prefix)
+	if err != nil {
+		return nil, err
+	}
+	return &b2Key{k}, nil
+}
+
+func (b *b2Root) createKeyMultiBucket(ctx context.Context, name string, caps []string, valid time.Duration, bucketIDs []string, prefix string) (b2KeyInterface, error) {
+	k, err := b.b.CreateKeyMultiBucket(ctx, name, caps, valid, bucketIDs, prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/b2/integration_test.go
+++ b/b2/integration_test.go
@@ -1037,6 +1037,11 @@ func TestListBucketsWithKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		if err := key.Delete(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
 
 	client, err := NewClient(ctx, key.ID(), key.Secret())
 	if err != nil {
@@ -1062,6 +1067,11 @@ func TestListBucketContentsWithKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		if err := key.Delete(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
 	client, err := NewClient(ctx, key.ID(), key.Secret())
 	if err != nil {
 		t.Fatal(err)

--- a/b2/integration_test.go
+++ b/b2/integration_test.go
@@ -1144,6 +1144,21 @@ func TestMultiBucketKeyListsAllowedBuckets(t *testing.T) {
 		t.Fatalf("NewClient with multi-bucket key: %v", err)
 	}
 
+	// An unfiltered b2_list_buckets is rejected for restricted keys, so this
+	// exercises the per-bucket fan-out.
+	listed, err := mbClient.ListBuckets(ctx)
+	if err != nil {
+		t.Fatalf("ListBuckets via multi-bucket key: %v", err)
+	}
+	got := map[string]bool{}
+	for _, b := range listed {
+		got[b.Name()] = true
+	}
+	want := map[string]bool{bucket1.Name(): true, bucket2.Name(): true}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ListBuckets via multi-bucket key = %v, want %v", got, want)
+	}
+
 	for _, b := range []*Bucket{bucket1, bucket2} {
 		ob, err := mbClient.Bucket(ctx, b.Name())
 		if err != nil {

--- a/b2/integration_test.go
+++ b/b2/integration_test.go
@@ -1090,6 +1090,82 @@ func TestListBucketContentsWithKey(t *testing.T) {
 	}
 }
 
+// TestMultiBucketKeyListsAllowedBuckets exercises the headline v4-only feature
+// end to end against live B2: it mints a Multi-Bucket Application Key scoped to
+// two buckets, authorizes with it (which only succeeds on v4), and confirms the
+// key can list within each allowed bucket.  If the v4 authorize response's
+// allowed scope were parsed incorrectly, the authorized client would not learn
+// its bucket scope and these list calls would fail with 401.
+func TestMultiBucketKeyListsAllowedBuckets(t *testing.T) {
+	ctx := context.Background()
+	bucket1, done := startLiveTest(ctx, t)
+	defer done()
+	client := bucket1.c
+
+	id := os.Getenv(apiID)
+	bucket2, err := client.NewBucket(ctx, fmt.Sprintf("%s-%s-mb-%s", id, bucketName, uniq), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		iter := bucket2.List(ctx, ListHidden())
+		for iter.Next() {
+			if err := iter.Object().Delete(ctx); err != nil {
+				t.Error(err)
+			}
+		}
+		if err := iter.Err(); err != nil && !IsNotExist(err) {
+			t.Error(err)
+		}
+		if err := bucket2.Delete(ctx); err != nil && !IsNotExist(err) {
+			t.Error(err)
+		}
+	}()
+
+	if _, _, err := writeFile(ctx, bucket1, "a", 1e5, 1e8); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := writeFile(ctx, bucket2, "b", 1e5, 1e8); err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := client.CreateKey(ctx, "multiBucketKey",
+		Capabilities("listBuckets", "listFiles", "readFiles"),
+		BucketIDs(bucket1.b.id(), bucket2.b.id()))
+	if err != nil {
+		t.Fatalf("CreateKey(BucketIDs): %v", err)
+	}
+	defer func() {
+		if err := key.Delete(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Authorizing with a multi-bucket key only works against v4.
+	mbClient, err := NewClient(ctx, key.ID(), key.Secret())
+	if err != nil {
+		t.Fatalf("NewClient with multi-bucket key: %v", err)
+	}
+
+	for _, b := range []*Bucket{bucket1, bucket2} {
+		ob, err := mbClient.Bucket(ctx, b.Name())
+		if err != nil {
+			t.Fatalf("Bucket(%s) via multi-bucket key: %v", b.Name(), err)
+		}
+		iter := ob.List(ctx)
+		var n int
+		for iter.Next() {
+			n++
+		}
+		if err := iter.Err(); err != nil {
+			t.Errorf("list %s via multi-bucket key: %v", b.Name(), err)
+		}
+		if n == 0 {
+			t.Errorf("list %s via multi-bucket key: got 0 objects, want >= 1", b.Name())
+		}
+	}
+}
+
 func TestCreateDeleteKey(t *testing.T) {
 	ctx := context.Background()
 	bucket, done := startLiveTest(ctx, t)

--- a/b2/integration_test.go
+++ b/b2/integration_test.go
@@ -1090,12 +1090,9 @@ func TestListBucketContentsWithKey(t *testing.T) {
 	}
 }
 
-// TestMultiBucketKeyListsAllowedBuckets exercises the headline v4-only feature
-// end to end against live B2: it mints a Multi-Bucket Application Key scoped to
-// two buckets, authorizes with it (which only succeeds on v4), and confirms the
-// key can list within each allowed bucket.  If the v4 authorize response's
-// allowed scope were parsed incorrectly, the authorized client would not learn
-// its bucket scope and these list calls would fail with 401.
+// TestMultiBucketKeyListsAllowedBuckets exercises the v4-only feature live:
+// mint a Multi-Bucket key over two buckets, authorize with it (v4 only), and
+// list within each. A misparsed allowed scope would surface as a 401 here.
 func TestMultiBucketKeyListsAllowedBuckets(t *testing.T) {
 	ctx := context.Background()
 	bucket1, done := startLiveTest(ctx, t)

--- a/b2/key.go
+++ b/b2/key.go
@@ -90,23 +90,18 @@ func Prefix(prefix string) KeyOption {
 	}
 }
 
-// BucketIDs restricts the requested application key to the given set of
-// bucket IDs.  This produces a Multi-Bucket Application Key and is only
-// valid on (*Client).CreateKey; bucket-scoped keys created via
-// (*Bucket).CreateKey already derive their bucket ID from the bucket.
-//
-// Keys created with more than one bucket ID can only be used with the B2
-// native API v4.
+// BucketIDs scopes the key to the given bucket IDs, producing a Multi-Bucket
+// Application Key. Valid only on (*Client).CreateKey, and usable only against
+// B2 native API v4.
 func BucketIDs(ids ...string) KeyOption {
 	return func(k *keyOptions) {
 		k.bucketIDs = append(k.bucketIDs, ids...)
 	}
 }
 
-// CreateKey creates an application key that is valid either for all buckets
-// in this project, or for an explicit set of buckets when the BucketIDs
-// option is supplied.  The key's secret will only be accessible on the
-// object returned from this call.
+// CreateKey creates an application key for all buckets in the project, or for
+// the buckets named by the BucketIDs option. The secret is only accessible on
+// the returned Key.
 func (c *Client) CreateKey(ctx context.Context, name string, opts ...KeyOption) (*Key, error) {
 	var ko keyOptions
 	for _, o := range opts {

--- a/b2/key.go
+++ b/b2/key.go
@@ -90,9 +90,10 @@ func Prefix(prefix string) KeyOption {
 	}
 }
 
-// BucketIDs scopes the key to the given bucket IDs, producing a Multi-Bucket
-// Application Key. Valid only on (*Client).CreateKey, and usable only against
-// B2 native API v4.
+// BucketIDs scopes the key to the given bucket IDs. A single ID produces a
+// legacy single-bucket key; two or more produce a Multi-Bucket Application
+// Key, which is usable only against B2 native API v4. Valid only on
+// (*Client).CreateKey.
 func BucketIDs(ids ...string) KeyOption {
 	return func(k *keyOptions) {
 		k.bucketIDs = append(k.bucketIDs, ids...)
@@ -114,10 +115,15 @@ func (c *Client) CreateKey(ctx context.Context, name string, opts ...KeyOption) 
 		ki  beKeyInterface
 		err error
 	)
-	if len(ko.bucketIDs) > 0 {
-		ki, err = c.backend.createKeyMultiBucket(ctx, name, ko.caps, ko.lifetime, ko.bucketIDs, ko.prefix)
-	} else {
+	switch len(ko.bucketIDs) {
+	case 0:
 		ki, err = c.backend.createKey(ctx, name, ko.caps, ko.lifetime, "", ko.prefix)
+	case 1:
+		// Single-bucket keys stay on the v3 endpoint: a v4-minted key cannot
+		// authorize against v3, so this keeps them usable by v3-only clients.
+		ki, err = c.backend.createKey(ctx, name, ko.caps, ko.lifetime, ko.bucketIDs[0], ko.prefix)
+	default:
+		ki, err = c.backend.createKeyMultiBucket(ctx, name, ko.caps, ko.lifetime, ko.bucketIDs, ko.prefix)
 	}
 	if err != nil {
 		return nil, err

--- a/b2/key.go
+++ b/b2/key.go
@@ -52,9 +52,10 @@ func (k *Key) Secret() string { return k.k.secret() }
 func (k *Key) ID() string { return k.k.id() }
 
 type keyOptions struct {
-	caps     []string
-	prefix   string
-	lifetime time.Duration
+	caps      []string
+	prefix    string
+	lifetime  time.Duration
+	bucketIDs []string
 }
 
 // KeyOption specifies desired properties for application keys.
@@ -89,18 +90,40 @@ func Prefix(prefix string) KeyOption {
 	}
 }
 
-// CreateKey creates a global application key that is valid for all buckets in
-// this project.  The key's secret will only be accessible on the object
-// returned from this call.
+// BucketIDs restricts the requested application key to the given set of
+// bucket IDs.  This produces a Multi-Bucket Application Key and is only
+// valid on (*Client).CreateKey; bucket-scoped keys created via
+// (*Bucket).CreateKey already derive their bucket ID from the bucket.
+//
+// Keys created with more than one bucket ID can only be used with the B2
+// native API v4.
+func BucketIDs(ids ...string) KeyOption {
+	return func(k *keyOptions) {
+		k.bucketIDs = append(k.bucketIDs, ids...)
+	}
+}
+
+// CreateKey creates an application key that is valid either for all buckets
+// in this project, or for an explicit set of buckets when the BucketIDs
+// option is supplied.  The key's secret will only be accessible on the
+// object returned from this call.
 func (c *Client) CreateKey(ctx context.Context, name string, opts ...KeyOption) (*Key, error) {
 	var ko keyOptions
 	for _, o := range opts {
 		o(&ko)
 	}
-	if ko.prefix != "" {
-		return nil, errors.New("Prefix is not a valid option for global application keys")
+	if ko.prefix != "" && len(ko.bucketIDs) == 0 {
+		return nil, errors.New("Prefix requires at least one bucket; use BucketIDs or create the key via (*Bucket).CreateKey")
 	}
-	ki, err := c.backend.createKey(ctx, name, ko.caps, ko.lifetime, "", "")
+	var (
+		ki  beKeyInterface
+		err error
+	)
+	if len(ko.bucketIDs) > 0 {
+		ki, err = c.backend.createKeyMultiBucket(ctx, name, ko.caps, ko.lifetime, ko.bucketIDs, ko.prefix)
+	} else {
+		ki, err = c.backend.createKey(ctx, name, ko.caps, ko.lifetime, "", ko.prefix)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -144,6 +167,9 @@ func (b *Bucket) CreateKey(ctx context.Context, name string, opts ...KeyOption) 
 	var ko keyOptions
 	for _, o := range opts {
 		o(&ko)
+	}
+	if len(ko.bucketIDs) > 0 {
+		return nil, errors.New("BucketIDs cannot be combined with (*Bucket).CreateKey; use (*Client).CreateKey to request a multi-bucket key")
 	}
 	ki, err := b.r.createKey(ctx, name, ko.caps, ko.lifetime, b.b.id(), ko.prefix)
 	if err != nil {

--- a/base/base.go
+++ b/base/base.go
@@ -486,10 +486,8 @@ func AuthorizeAccount(ctx context.Context, account, key string, opts ...AuthOpti
 		return nil, err
 	}
 	storageAPI := b2resp.APIInfo.StorageAPIInfo
-	// For restricted keys, the v4 authorize-account response carries the key's
-	// scope under apiInfo.storageApi.allowed: a list of {id, name} buckets and
-	// an optional name prefix. Unrestricted (master) keys have a nil/empty
-	// allowed, leaving buckets and pfx empty.
+	// A restricted key's scope lives under storageApi.allowed; it's nil for
+	// unrestricted keys, leaving buckets and pfx empty.
 	var buckets []string
 	var pfx string
 	if allowed := storageAPI.Allowed; allowed != nil {
@@ -723,10 +721,9 @@ func (b *Bucket) S3URL() string {
 // ListBuckets wraps b2_list_buckets.  If name is non-empty, only that bucket
 // will be returned if it exists; else nothing will be returned.
 func (b *B2) ListBuckets(ctx context.Context, name string, bucketTypes ...string) ([]*Bucket, error) {
-	// b2_list_buckets only accepts a single bucketId filter. When the key is
-	// restricted to exactly one bucket we pass it explicitly; otherwise we
-	// omit the filter and rely on B2's server-side enforcement of the key's
-	// allowed bucket list.
+	// b2_list_buckets filters on at most one bucketId, so only a single-bucket
+	// key can be pre-filtered here; multi-bucket keys rely on B2's server-side
+	// scope enforcement.
 	var filterBucketID string
 	if len(b.buckets) == 1 {
 		filterBucketID = b.buckets[0]
@@ -1364,12 +1361,9 @@ type Key struct {
 	b2           *B2
 }
 
-// CreateKey wraps b2_create_key on the v3 endpoint and produces a legacy
-// single-bucket application key: if bucketID is non-empty the key is
-// restricted to that one bucket, otherwise it is unrestricted.  Keys
-// created this way are compatible with clients that still speak the B2
-// native API v3.  To create a Multi-Bucket Application Key, use
-// CreateKeyMultiBucket.
+// CreateKey wraps v3 b2_create_key, producing a single-bucket key (or, with an
+// empty bucketID, an unrestricted one) that v3-only clients can still use. For
+// a Multi-Bucket Application Key, use CreateKeyMultiBucket.
 func (b *B2) CreateKey(ctx context.Context, name string, caps []string, valid time.Duration, bucketID string, prefix string) (*Key, error) {
 	b2req := &b2types.CreateKeyRequestV3{
 		AccountID:    b.accountID,
@@ -1382,11 +1376,9 @@ func (b *B2) CreateKey(ctx context.Context, name string, caps []string, valid ti
 	return b.doCreateKey(ctx, b2types.V3api, b2req)
 }
 
-// CreateKeyMultiBucket wraps b2_create_key on the v4 endpoint and produces
-// a Multi-Bucket Application Key scoped to the given bucket IDs.  Keys
-// produced by this method cannot be used by clients that only speak the B2
-// native API v3.  If backward compatibility with v3-only clients matters,
-// create one key per bucket with CreateKey instead.
+// CreateKeyMultiBucket wraps v4 b2_create_key, producing a Multi-Bucket
+// Application Key. Such keys are unusable by v3-only clients; for v3
+// compatibility, create one CreateKey per bucket instead.
 func (b *B2) CreateKeyMultiBucket(ctx context.Context, name string, caps []string, valid time.Duration, bucketIDs []string, prefix string) (*Key, error) {
 	b2req := &b2types.CreateKeyRequestV4{
 		AccountID:    b.accountID,

--- a/base/base.go
+++ b/base/base.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	APIBase          = "https://api.backblazeb2.com"
-	DefaultUserAgent = "blazer/0.7.2"
+	DefaultUserAgent = "blazer/0.8.0"
 )
 
 type b2err struct {

--- a/base/base.go
+++ b/base/base.go
@@ -310,8 +310,8 @@ type B2 struct {
 	downloadURI string
 	minPartSize int
 	opts        *b2Options
-	bucket      string // restricted to this bucket if present
-	pfx         string // restricted to objects with this prefix if present
+	buckets     []string // restricted to these buckets if non-empty
+	pfx         string   // restricted to objects with this prefix if present
 }
 
 // Update replaces the B2 object with a new one, in-place.
@@ -482,7 +482,7 @@ func AuthorizeAccount(ctx context.Context, account, key string, opts ...AuthOpti
 	for _, f := range opts {
 		f(b2opts)
 	}
-	if err := b2opts.makeRequest(ctx, "b2_authorize_account", "GET", b2opts.getAPIBase()+b2types.V3api+"b2_authorize_account", nil, b2resp, headers, nil); err != nil {
+	if err := b2opts.makeRequest(ctx, "b2_authorize_account", "GET", b2opts.getAPIBase()+b2types.V4api+"b2_authorize_account", nil, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	return &B2{
@@ -492,7 +492,7 @@ func AuthorizeAccount(ctx context.Context, account, key string, opts ...AuthOpti
 		s3URI:       b2resp.APIInfo.StorageAPIInfo.S3URI,
 		downloadURI: b2resp.APIInfo.StorageAPIInfo.DownloadURI,
 		minPartSize: b2resp.APIInfo.StorageAPIInfo.AbsMinPartSize,
-		bucket:      b2resp.APIInfo.StorageAPIInfo.Bucket,
+		buckets:     b2resp.APIInfo.StorageAPIInfo.BucketIDs,
 		pfx:         b2resp.APIInfo.StorageAPIInfo.Prefix,
 		opts:        b2opts,
 	}, nil
@@ -583,7 +583,7 @@ func (b *B2) CreateBucket(ctx context.Context, name, btype string, info map[stri
 	headers := map[string]string{
 		"Authorization": b.authToken,
 	}
-	if err := b.opts.makeRequest(ctx, "b2_create_bucket", "POST", b.apiURI+b2types.V3api+"b2_create_bucket", b2req, b2resp, headers, nil); err != nil {
+	if err := b.opts.makeRequest(ctx, "b2_create_bucket", "POST", b.apiURI+b2types.V4api+"b2_create_bucket", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	var respRules []LifecycleRule
@@ -613,7 +613,7 @@ func (b *Bucket) DeleteBucket(ctx context.Context) error {
 	headers := map[string]string{
 		"Authorization": b.b2.authToken,
 	}
-	return b.b2.opts.makeRequest(ctx, "b2_delete_bucket", "POST", b.b2.apiURI+b2types.V3api+"b2_delete_bucket", b2req, nil, headers, nil)
+	return b.b2.opts.makeRequest(ctx, "b2_delete_bucket", "POST", b.b2.apiURI+b2types.V4api+"b2_delete_bucket", b2req, nil, headers, nil)
 }
 
 // Bucket holds B2 bucket details.
@@ -662,7 +662,7 @@ func (b *Bucket) Update(ctx context.Context) (*Bucket, error) {
 		"Authorization": b.b2.authToken,
 	}
 	b2resp := &b2types.UpdateBucketResponse{}
-	if err := b.b2.opts.makeRequest(ctx, "b2_update_bucket", "POST", b.b2.apiURI+b2types.V3api+"b2_update_bucket", b2req, b2resp, headers, nil); err != nil {
+	if err := b.b2.opts.makeRequest(ctx, "b2_update_bucket", "POST", b.b2.apiURI+b2types.V4api+"b2_update_bucket", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	var respRules []LifecycleRule
@@ -710,9 +710,17 @@ func (b *Bucket) S3URL() string {
 // ListBuckets wraps b2_list_buckets.  If name is non-empty, only that bucket
 // will be returned if it exists; else nothing will be returned.
 func (b *B2) ListBuckets(ctx context.Context, name string, bucketTypes ...string) ([]*Bucket, error) {
+	// b2_list_buckets only accepts a single bucketId filter. When the key is
+	// restricted to exactly one bucket we pass it explicitly; otherwise we
+	// omit the filter and rely on B2's server-side enforcement of the key's
+	// allowed bucket list.
+	var filterBucketID string
+	if len(b.buckets) == 1 {
+		filterBucketID = b.buckets[0]
+	}
 	b2req := &b2types.ListBucketsRequest{
 		AccountID:   b.accountID,
-		Bucket:      b.bucket,
+		Bucket:      filterBucketID,
 		Name:        name,
 		BucketTypes: bucketTypes,
 	}
@@ -720,7 +728,7 @@ func (b *B2) ListBuckets(ctx context.Context, name string, bucketTypes ...string
 	headers := map[string]string{
 		"Authorization": b.authToken,
 	}
-	if err := b.opts.makeRequest(ctx, "b2_list_buckets", "POST", b.apiURI+b2types.V3api+"b2_list_buckets", b2req, b2resp, headers, nil); err != nil {
+	if err := b.opts.makeRequest(ctx, "b2_list_buckets", "POST", b.apiURI+b2types.V4api+"b2_list_buckets", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	var buckets []*Bucket
@@ -775,7 +783,7 @@ func (b *Bucket) GetUploadURL(ctx context.Context) (*URL, error) {
 	headers := map[string]string{
 		"Authorization": b.b2.authToken,
 	}
-	if err := b.b2.opts.makeRequest(ctx, "b2_get_upload_url", "POST", b.b2.apiURI+b2types.V3api+"b2_get_upload_url", b2req, b2resp, headers, nil); err != nil {
+	if err := b.b2.opts.makeRequest(ctx, "b2_get_upload_url", "POST", b.b2.apiURI+b2types.V4api+"b2_get_upload_url", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	return &URL{
@@ -843,7 +851,7 @@ func (f *File) DeleteFileVersion(ctx context.Context) error {
 	headers := map[string]string{
 		"Authorization": f.b2.authToken,
 	}
-	return f.b2.opts.makeRequest(ctx, "b2_delete_file_version", "POST", f.b2.apiURI+b2types.V3api+"b2_delete_file_version", b2req, nil, headers, nil)
+	return f.b2.opts.makeRequest(ctx, "b2_delete_file_version", "POST", f.b2.apiURI+b2types.V4api+"b2_delete_file_version", b2req, nil, headers, nil)
 }
 
 // LargeFile holds information necessary to implement B2 large file support.
@@ -868,7 +876,7 @@ func (b *Bucket) StartLargeFile(ctx context.Context, name, contentType string, i
 	headers := map[string]string{
 		"Authorization": b.b2.authToken,
 	}
-	if err := b.b2.opts.makeRequest(ctx, "b2_start_large_file", "POST", b.b2.apiURI+b2types.V3api+"b2_start_large_file", b2req, b2resp, headers, nil); err != nil {
+	if err := b.b2.opts.makeRequest(ctx, "b2_start_large_file", "POST", b.b2.apiURI+b2types.V4api+"b2_start_large_file", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	return &LargeFile{
@@ -886,7 +894,7 @@ func (l *LargeFile) CancelLargeFile(ctx context.Context) error {
 	headers := map[string]string{
 		"Authorization": l.b2.authToken,
 	}
-	return l.b2.opts.makeRequest(ctx, "b2_cancel_large_file", "POST", l.b2.apiURI+b2types.V3api+"b2_cancel_large_file", b2req, nil, headers, nil)
+	return l.b2.opts.makeRequest(ctx, "b2_cancel_large_file", "POST", l.b2.apiURI+b2types.V4api+"b2_cancel_large_file", b2req, nil, headers, nil)
 }
 
 // FilePart is a piece of a started, but not finished, large file upload.
@@ -907,7 +915,7 @@ func (f *File) ListParts(ctx context.Context, next, count int) ([]*FilePart, int
 	headers := map[string]string{
 		"Authorization": f.b2.authToken,
 	}
-	if err := f.b2.opts.makeRequest(ctx, "b2_list_parts", "POST", f.b2.apiURI+b2types.V3api+"b2_list_parts", b2req, b2resp, headers, nil); err != nil {
+	if err := f.b2.opts.makeRequest(ctx, "b2_list_parts", "POST", f.b2.apiURI+b2types.V4api+"b2_list_parts", b2req, b2resp, headers, nil); err != nil {
 		return nil, 0, err
 	}
 	var parts []*FilePart
@@ -962,7 +970,7 @@ func (l *LargeFile) GetUploadPartURL(ctx context.Context) (*FileChunk, error) {
 	headers := map[string]string{
 		"Authorization": l.b2.authToken,
 	}
-	if err := l.b2.opts.makeRequest(ctx, "b2_get_upload_part_url", "POST", l.b2.apiURI+b2types.V3api+"b2_get_upload_part_url", b2req, b2resp, headers, nil); err != nil {
+	if err := l.b2.opts.makeRequest(ctx, "b2_get_upload_part_url", "POST", l.b2.apiURI+b2types.V4api+"b2_get_upload_part_url", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	return &FileChunk{
@@ -1025,7 +1033,7 @@ func (l *LargeFile) FinishLargeFile(ctx context.Context) (*File, error) {
 	headers := map[string]string{
 		"Authorization": l.b2.authToken,
 	}
-	if err := l.b2.opts.makeRequest(ctx, "b2_finish_large_file", "POST", l.b2.apiURI+b2types.V3api+"b2_finish_large_file", b2req, b2resp, headers, nil); err != nil {
+	if err := l.b2.opts.makeRequest(ctx, "b2_finish_large_file", "POST", l.b2.apiURI+b2types.V4api+"b2_finish_large_file", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	return &File{
@@ -1049,7 +1057,7 @@ func (b *Bucket) ListUnfinishedLargeFiles(ctx context.Context, count int, contin
 	headers := map[string]string{
 		"Authorization": b.b2.authToken,
 	}
-	if err := b.b2.opts.makeRequest(ctx, "b2_list_unfinished_large_files", "POST", b.b2.apiURI+b2types.V3api+"b2_list_unfinished_large_files", b2req, b2resp, headers, nil); err != nil {
+	if err := b.b2.opts.makeRequest(ctx, "b2_list_unfinished_large_files", "POST", b.b2.apiURI+b2types.V4api+"b2_list_unfinished_large_files", b2req, b2resp, headers, nil); err != nil {
 		return nil, "", err
 	}
 	cont := b2resp.Continuation
@@ -1088,7 +1096,7 @@ func (b *Bucket) ListFileNames(ctx context.Context, count int, continuation, pre
 	headers := map[string]string{
 		"Authorization": b.b2.authToken,
 	}
-	if err := b.b2.opts.makeRequest(ctx, "b2_list_file_names", "POST", b.b2.apiURI+b2types.V3api+"b2_list_file_names", b2req, b2resp, headers, nil); err != nil {
+	if err := b.b2.opts.makeRequest(ctx, "b2_list_file_names", "POST", b.b2.apiURI+b2types.V4api+"b2_list_file_names", b2req, b2resp, headers, nil); err != nil {
 		return nil, "", err
 	}
 	cont := b2resp.Continuation
@@ -1133,7 +1141,7 @@ func (b *Bucket) ListFileVersions(ctx context.Context, count int, startName, sta
 	headers := map[string]string{
 		"Authorization": b.b2.authToken,
 	}
-	if err := b.b2.opts.makeRequest(ctx, "b2_list_file_versions", "POST", b.b2.apiURI+b2types.V3api+"b2_list_file_versions", b2req, b2resp, headers, nil); err != nil {
+	if err := b.b2.opts.makeRequest(ctx, "b2_list_file_versions", "POST", b.b2.apiURI+b2types.V4api+"b2_list_file_versions", b2req, b2resp, headers, nil); err != nil {
 		return nil, "", "", err
 	}
 	var files []*File
@@ -1172,7 +1180,7 @@ func (b *Bucket) GetDownloadAuthorization(ctx context.Context, prefix string, va
 	headers := map[string]string{
 		"Authorization": b.b2.authToken,
 	}
-	if err := b.b2.opts.makeRequest(ctx, "b2_get_download_authorization", "POST", b.b2.apiURI+b2types.V3api+"b2_get_download_authorization", b2req, b2resp, headers, nil); err != nil {
+	if err := b.b2.opts.makeRequest(ctx, "b2_get_download_authorization", "POST", b.b2.apiURI+b2types.V4api+"b2_get_download_authorization", b2req, b2resp, headers, nil); err != nil {
 		return "", err
 	}
 	return b2resp.Token, nil
@@ -1273,7 +1281,7 @@ func (b *Bucket) HideFile(ctx context.Context, name string) (*File, error) {
 	headers := map[string]string{
 		"Authorization": b.b2.authToken,
 	}
-	if err := b.b2.opts.makeRequest(ctx, "b2_hide_file", "POST", b.b2.apiURI+b2types.V3api+"b2_hide_file", b2req, b2resp, headers, nil); err != nil {
+	if err := b.b2.opts.makeRequest(ctx, "b2_hide_file", "POST", b.b2.apiURI+b2types.V4api+"b2_hide_file", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	return &File{
@@ -1306,7 +1314,7 @@ func (f *File) GetFileInfo(ctx context.Context) (*FileInfo, error) {
 	headers := map[string]string{
 		"Authorization": f.b2.authToken,
 	}
-	if err := f.b2.opts.makeRequest(ctx, "b2_get_file_info", "POST", f.b2.apiURI+b2types.V3api+"b2_get_file_info", b2req, b2resp, headers, nil); err != nil {
+	if err := f.b2.opts.makeRequest(ctx, "b2_get_file_info", "POST", f.b2.apiURI+b2types.V4api+"b2_get_file_info", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	f.Status = b2resp.Action
@@ -1343,9 +1351,14 @@ type Key struct {
 	b2           *B2
 }
 
-// CreateKey wraps b2_create_key.
+// CreateKey wraps b2_create_key on the v3 endpoint and produces a legacy
+// single-bucket application key: if bucketID is non-empty the key is
+// restricted to that one bucket, otherwise it is unrestricted.  Keys
+// created this way are compatible with clients that still speak the B2
+// native API v3.  To create a Multi-Bucket Application Key, use
+// CreateKeyMultiBucket.
 func (b *B2) CreateKey(ctx context.Context, name string, caps []string, valid time.Duration, bucketID string, prefix string) (*Key, error) {
-	b2req := &b2types.CreateKeyRequest{
+	b2req := &b2types.CreateKeyRequestV3{
 		AccountID:    b.accountID,
 		Capabilities: caps,
 		Name:         name,
@@ -1353,11 +1366,32 @@ func (b *B2) CreateKey(ctx context.Context, name string, caps []string, valid ti
 		BucketID:     bucketID,
 		Prefix:       prefix,
 	}
+	return b.doCreateKey(ctx, b2types.V3api, b2req)
+}
+
+// CreateKeyMultiBucket wraps b2_create_key on the v4 endpoint and produces
+// a Multi-Bucket Application Key scoped to the given bucket IDs.  Keys
+// produced by this method cannot be used by clients that only speak the B2
+// native API v3.  If backward compatibility with v3-only clients matters,
+// create one key per bucket with CreateKey instead.
+func (b *B2) CreateKeyMultiBucket(ctx context.Context, name string, caps []string, valid time.Duration, bucketIDs []string, prefix string) (*Key, error) {
+	b2req := &b2types.CreateKeyRequestV4{
+		AccountID:    b.accountID,
+		Capabilities: caps,
+		Name:         name,
+		Valid:        int(valid.Seconds()),
+		BucketIDs:    bucketIDs,
+		Prefix:       prefix,
+	}
+	return b.doCreateKey(ctx, b2types.V4api, b2req)
+}
+
+func (b *B2) doCreateKey(ctx context.Context, apiVersion string, b2req interface{}) (*Key, error) {
 	b2resp := &b2types.CreateKeyResponse{}
 	headers := map[string]string{
 		"Authorization": b.authToken,
 	}
-	if err := b.opts.makeRequest(ctx, "b2_create_key", "POST", b.apiURI+b2types.V3api+"b2_create_key", b2req, b2resp, headers, nil); err != nil {
+	if err := b.opts.makeRequest(ctx, "b2_create_key", "POST", b.apiURI+apiVersion+"b2_create_key", b2req, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
 	return &Key{
@@ -1378,7 +1412,7 @@ func (k *Key) Delete(ctx context.Context) error {
 	headers := map[string]string{
 		"Authorization": k.b2.authToken,
 	}
-	return k.b2.opts.makeRequest(ctx, "b2_delete_key", "POST", k.b2.apiURI+b2types.V3api+"b2_delete_key", b2req, nil, headers, nil)
+	return k.b2.opts.makeRequest(ctx, "b2_delete_key", "POST", k.b2.apiURI+b2types.V4api+"b2_delete_key", b2req, nil, headers, nil)
 }
 
 // ListKeys wraps b2_list_keys.
@@ -1392,7 +1426,7 @@ func (b *B2) ListKeys(ctx context.Context, max int, next string) ([]*Key, string
 		"Authorization": b.authToken,
 	}
 	b2resp := &b2types.ListKeysResponse{}
-	if err := b.opts.makeRequest(ctx, "b2_list_keys", "POST", b.apiURI+b2types.V3api+"b2_list_keys", b2req, b2resp, headers, nil); err != nil {
+	if err := b.opts.makeRequest(ctx, "b2_list_keys", "POST", b.apiURI+b2types.V4api+"b2_list_keys", b2req, b2resp, headers, nil); err != nil {
 		return nil, "", err
 	}
 	var keys []*Key

--- a/base/base.go
+++ b/base/base.go
@@ -486,8 +486,9 @@ func AuthorizeAccount(ctx context.Context, account, key string, opts ...AuthOpti
 		return nil, err
 	}
 	storageAPI := b2resp.APIInfo.StorageAPIInfo
-	// A restricted key's scope lives under storageApi.allowed; it's nil for
-	// unrestricted keys, leaving buckets and pfx empty.
+	// A restricted key's scope lives under storageApi.allowed. Master keys
+	// carry an allowed with null buckets and namePrefix, leaving buckets and
+	// pfx empty; the nil check also tolerates an absent allowed.
 	var buckets []string
 	var pfx string
 	if allowed := storageAPI.Allowed; allowed != nil {

--- a/base/base.go
+++ b/base/base.go
@@ -322,6 +322,8 @@ func (b *B2) Update(n *B2) {
 	b.downloadURI = n.downloadURI
 	b.minPartSize = n.minPartSize
 	b.opts = n.opts
+	b.buckets = n.buckets
+	b.pfx = n.pfx
 }
 
 type httpReply struct {

--- a/base/base.go
+++ b/base/base.go
@@ -721,16 +721,33 @@ func (b *Bucket) S3URL() string {
 // ListBuckets wraps b2_list_buckets.  If name is non-empty, only that bucket
 // will be returned if it exists; else nothing will be returned.
 func (b *B2) ListBuckets(ctx context.Context, name string, bucketTypes ...string) ([]*Bucket, error) {
-	// b2_list_buckets filters on at most one bucketId, so only a single-bucket
-	// key can be pre-filtered here; multi-bucket keys rely on B2's server-side
-	// scope enforcement.
+	// b2_list_buckets does not narrow results to a restricted key's scope: it
+	// rejects any unfiltered request from such a key with 401, and accepts at
+	// most one bucketId filter per request. A single-bucket key can send its
+	// bucket as the filter; a multi-bucket key with no name filter has to fan
+	// out one request per allowed bucket and merge the results.
+	if name == "" && len(b.buckets) > 1 {
+		var buckets []*Bucket
+		for _, id := range b.buckets {
+			bs, err := b.listBuckets(ctx, id, "", bucketTypes)
+			if err != nil {
+				return nil, err
+			}
+			buckets = append(buckets, bs...)
+		}
+		return buckets, nil
+	}
 	var filterBucketID string
 	if len(b.buckets) == 1 {
 		filterBucketID = b.buckets[0]
 	}
+	return b.listBuckets(ctx, filterBucketID, name, bucketTypes)
+}
+
+func (b *B2) listBuckets(ctx context.Context, bucketID, name string, bucketTypes []string) ([]*Bucket, error) {
 	b2req := &b2types.ListBucketsRequest{
 		AccountID:   b.accountID,
-		Bucket:      filterBucketID,
+		Bucket:      bucketID,
 		Name:        name,
 		BucketTypes: bucketTypes,
 	}

--- a/base/base.go
+++ b/base/base.go
@@ -485,15 +485,28 @@ func AuthorizeAccount(ctx context.Context, account, key string, opts ...AuthOpti
 	if err := b2opts.makeRequest(ctx, "b2_authorize_account", "GET", b2opts.getAPIBase()+b2types.V4api+"b2_authorize_account", nil, b2resp, headers, nil); err != nil {
 		return nil, err
 	}
+	storageAPI := b2resp.APIInfo.StorageAPIInfo
+	// For restricted keys, the v4 authorize-account response carries the key's
+	// scope under apiInfo.storageApi.allowed: a list of {id, name} buckets and
+	// an optional name prefix. Unrestricted (master) keys have a nil/empty
+	// allowed, leaving buckets and pfx empty.
+	var buckets []string
+	var pfx string
+	if allowed := storageAPI.Allowed; allowed != nil {
+		for _, b := range allowed.Buckets {
+			buckets = append(buckets, b.ID)
+		}
+		pfx = allowed.Prefix
+	}
 	return &B2{
 		accountID:   b2resp.AccountID,
 		authToken:   b2resp.AuthToken,
-		apiURI:      b2resp.APIInfo.StorageAPIInfo.URI,
-		s3URI:       b2resp.APIInfo.StorageAPIInfo.S3URI,
-		downloadURI: b2resp.APIInfo.StorageAPIInfo.DownloadURI,
-		minPartSize: b2resp.APIInfo.StorageAPIInfo.AbsMinPartSize,
-		buckets:     b2resp.APIInfo.StorageAPIInfo.BucketIDs,
-		pfx:         b2resp.APIInfo.StorageAPIInfo.Prefix,
+		apiURI:      storageAPI.URI,
+		s3URI:       storageAPI.S3URI,
+		downloadURI: storageAPI.DownloadURI,
+		minPartSize: storageAPI.AbsMinPartSize,
+		buckets:     buckets,
+		pfx:         pfx,
 		opts:        b2opts,
 	}, nil
 }

--- a/base/base_v4_test.go
+++ b/base/base_v4_test.go
@@ -26,15 +26,9 @@ import (
 	"testing"
 )
 
-// v4AuthJSON returns an authorizeAccount response body in the v4 shape.  The
-// apiUrl points back at the test server so follow-up calls (CreateKey, etc.)
-// hit the same handler.
-//
-// A restricted key's scope is nested under apiInfo.storageApi.allowed: buckets
-// is a list of {id, name} objects and namePrefix an optional string.  bucketIDs
-// and bucketNames are zipped into that list (they must be the same length).
-// When bucketIDs is empty the key is treated as unrestricted and allowed is
-// omitted entirely, matching B2's response for master keys.
+// v4AuthJSON builds a v4-shaped authorizeAccount response whose apiUrl points
+// back at the test server. bucketIDs/bucketNames (equal length) are zipped into
+// allowed.buckets; an empty scope omits allowed, as B2 does for master keys.
 func v4AuthJSON(apiURL string, bucketIDs, bucketNames []string, namePrefix string) string {
 	storageAPI := map[string]any{
 		"absoluteMinimumPartSize": 5000000,
@@ -105,7 +99,7 @@ func TestAuthorizeAccountV4(t *testing.T) {
 }
 
 func TestAuthorizeAccountV4UnrestrictedKey(t *testing.T) {
-	// Unrestricted keys return null/empty arrays for bucketIds/bucketNames.
+	// Unrestricted keys carry no allowed block.
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, v4AuthJSON(srv.URL, nil, nil, ""))
@@ -124,15 +118,12 @@ func TestAuthorizeAccountV4UnrestrictedKey(t *testing.T) {
 	}
 }
 
-// TestAuthorizeAccountV4ReadsAllowedNesting guards against regressing to the v3
-// shape, where the key's scope sat at the storageApi top level.  In v4 the scope
-// lives under storageApi.allowed; a response with top-level bucketIds/namePrefix
-// (and an empty allowed) must yield no restrictions.
+// TestAuthorizeAccountV4ReadsAllowedNesting pins the fix: v4 scope lives under
+// storageApi.allowed, so top-level v3-style bucketIds/namePrefix are ignored.
 func TestAuthorizeAccountV4ReadsAllowedNesting(t *testing.T) {
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Deliberately place scope at the (wrong) v3 top level and leave
-		// allowed absent.  A correct v4 parser ignores these.
+		// Scope at the (wrong) v3 top level, with no allowed block.
 		resp := map[string]any{
 			"accountId":          "account-id",
 			"authorizationToken": "auth-token",
@@ -165,9 +156,8 @@ func TestAuthorizeAccountV4ReadsAllowedNesting(t *testing.T) {
 	}
 }
 
-// TestAuthorizeAccountV4SingleBucketRestrictedKey covers the headline regression:
-// a bucket-restricted key whose scope is nested under storageApi.allowed must be
-// surfaced so the client knows which bucket it may use.
+// TestAuthorizeAccountV4SingleBucketRestrictedKey checks the headline case: a
+// restricted key's nested scope is surfaced so the client knows its bucket.
 func TestAuthorizeAccountV4SingleBucketRestrictedKey(t *testing.T) {
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -184,10 +174,8 @@ func TestAuthorizeAccountV4SingleBucketRestrictedKey(t *testing.T) {
 	}
 }
 
-// createKeyFixture wires up a test server that first handles authorize_account
-// then records and responds to a single b2_create_key request.  It returns the
-// authorized B2, plus pointers to captured request metadata the caller can
-// inspect after making the create_key call.
+// createKeyFixture serves authorize_account, then captures the single
+// b2_create_key request (path, method, body) for the caller to inspect.
 type createKeyFixture struct {
 	b2         *B2
 	srv        *httptest.Server

--- a/base/base_v4_test.go
+++ b/base/base_v4_test.go
@@ -28,8 +28,17 @@ import (
 
 // v4AuthJSON builds a v4-shaped authorizeAccount response whose apiUrl points
 // back at the test server. bucketIDs/bucketNames (equal length) are zipped into
-// allowed.buckets; an empty scope omits allowed, as B2 does for master keys.
+// allowed.buckets. allowed is always present; an empty scope carries null
+// buckets and namePrefix, the shape B2 returns for master keys.
 func v4AuthJSON(apiURL string, bucketIDs, bucketNames []string, namePrefix string) string {
+	var buckets []map[string]any // nil marshals to null, the master-key shape
+	for i, id := range bucketIDs {
+		buckets = append(buckets, map[string]any{"id": id, "name": bucketNames[i]})
+	}
+	var prefix any // null when unset
+	if namePrefix != "" {
+		prefix = namePrefix
+	}
 	storageAPI := map[string]any{
 		"absoluteMinimumPartSize": 5000000,
 		"apiUrl":                  apiURL,
@@ -38,17 +47,11 @@ func v4AuthJSON(apiURL string, bucketIDs, bucketNames []string, namePrefix strin
 		"storageApi":              "storage",
 		"recommendedPartSize":     100000000,
 		"s3ApiUrl":                apiURL,
-	}
-	if len(bucketIDs) > 0 || namePrefix != "" {
-		buckets := make([]map[string]any, len(bucketIDs))
-		for i, id := range bucketIDs {
-			buckets[i] = map[string]any{"id": id, "name": bucketNames[i]}
-		}
-		storageAPI["allowed"] = map[string]any{
+		"allowed": map[string]any{
 			"buckets":      buckets,
 			"capabilities": []string{"readFiles", "writeFiles"},
-			"namePrefix":   namePrefix,
-		}
+			"namePrefix":   prefix,
+		},
 	}
 	resp := map[string]any{
 		"accountId":                         "account-id",
@@ -99,7 +102,8 @@ func TestAuthorizeAccountV4(t *testing.T) {
 }
 
 func TestAuthorizeAccountV4UnrestrictedKey(t *testing.T) {
-	// Unrestricted keys carry no allowed block.
+	// Master keys still carry an allowed block, but with null buckets and
+	// namePrefix.
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, v4AuthJSON(srv.URL, nil, nil, ""))

--- a/base/base_v4_test.go
+++ b/base/base_v4_test.go
@@ -178,6 +178,24 @@ func TestAuthorizeAccountV4SingleBucketRestrictedKey(t *testing.T) {
 	}
 }
 
+// TestUpdateCarriesScope guards re-auth: a re-authorized B2 must keep the
+// key's bucket and prefix restrictions, or scope-aware calls like ListBuckets
+// silently regress to unrestricted behavior.
+func TestUpdateCarriesScope(t *testing.T) {
+	b := &B2{}
+	b.Update(&B2{
+		accountID: "account-id",
+		buckets:   []string{"buck-a", "buck-b"},
+		pfx:       "restic/",
+	})
+	if want := []string{"buck-a", "buck-b"}; !reflect.DeepEqual(b.buckets, want) {
+		t.Errorf("buckets = %v, want %v", b.buckets, want)
+	}
+	if b.pfx != "restic/" {
+		t.Errorf("pfx = %q, want %q", b.pfx, "restic/")
+	}
+}
+
 // TestListBucketsFansOutForMultiBucketKeys pins the fan-out: b2_list_buckets
 // rejects any unfiltered request from a restricted key with 401 and accepts at
 // most one bucketId filter, so a multi-bucket key must issue one filtered

--- a/base/base_v4_test.go
+++ b/base/base_v4_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026, the Blazer authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// v4AuthJSON returns an authorizeAccount response body in the v4 shape.  The
+// apiUrl points back at the test server so follow-up calls (CreateKey, etc.)
+// hit the same handler.
+func v4AuthJSON(apiURL string, bucketIDs, bucketNames []string, namePrefix string) string {
+	resp := map[string]any{
+		"accountId":                         "account-id",
+		"authorizationToken":                "auth-token",
+		"applicationKeyExpirationTimestamp": 0,
+		"apiInfo": map[string]any{
+			"storageApi": map[string]any{
+				"absoluteMinimumPartSize": 5000000,
+				"apiUrl":                  apiURL,
+				"bucketIds":               bucketIDs,
+				"bucketNames":             bucketNames,
+				"capabilities":            []string{"readFiles", "writeFiles"},
+				"downloadUrl":             apiURL,
+				"storageApi":              "storage",
+				"namePrefix":              namePrefix,
+				"recommendedPartSize":     100000000,
+				"s3ApiUrl":                apiURL,
+			},
+		},
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func TestAuthorizeAccountV4(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/b2api/v4/b2_authorize_account" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		fmt.Fprint(w, v4AuthJSON(srv.URL, []string{"buck-a", "buck-b"}, []string{"name-a", "name-b"}, "restic/"))
+	}))
+	defer srv.Close()
+
+	b, err := AuthorizeAccount(context.Background(), "account-id", "application-key", SetAPIBase(srv.URL))
+	if err != nil {
+		t.Fatalf("AuthorizeAccount: %v", err)
+	}
+	if want := []string{"buck-a", "buck-b"}; !reflect.DeepEqual(b.buckets, want) {
+		t.Errorf("buckets = %v, want %v", b.buckets, want)
+	}
+	if b.pfx != "restic/" {
+		t.Errorf("pfx = %q, want %q", b.pfx, "restic/")
+	}
+	if b.apiURI != srv.URL {
+		t.Errorf("apiURI = %q, want %q", b.apiURI, srv.URL)
+	}
+	if b.accountID != "account-id" {
+		t.Errorf("accountID = %q, want %q", b.accountID, "account-id")
+	}
+}
+
+func TestAuthorizeAccountV4UnrestrictedKey(t *testing.T) {
+	// Unrestricted keys return null/empty arrays for bucketIds/bucketNames.
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, v4AuthJSON(srv.URL, nil, nil, ""))
+	}))
+	defer srv.Close()
+
+	b, err := AuthorizeAccount(context.Background(), "account-id", "application-key", SetAPIBase(srv.URL))
+	if err != nil {
+		t.Fatalf("AuthorizeAccount: %v", err)
+	}
+	if len(b.buckets) != 0 {
+		t.Errorf("buckets = %v, want empty", b.buckets)
+	}
+	if b.pfx != "" {
+		t.Errorf("pfx = %q, want empty", b.pfx)
+	}
+}
+
+// createKeyFixture wires up a test server that first handles authorize_account
+// then records and responds to a single b2_create_key request.  It returns the
+// authorized B2, plus pointers to captured request metadata the caller can
+// inspect after making the create_key call.
+type createKeyFixture struct {
+	b2         *B2
+	srv        *httptest.Server
+	lastPath   string
+	lastBody   map[string]any
+	lastMethod string
+}
+
+func newCreateKeyFixture(t *testing.T) *createKeyFixture {
+	t.Helper()
+	f := &createKeyFixture{}
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/b2api/v4/b2_authorize_account":
+			fmt.Fprint(w, v4AuthJSON(f.srv.URL, nil, nil, ""))
+		case strings.HasSuffix(r.URL.Path, "/b2_create_key"):
+			f.lastPath = r.URL.Path
+			f.lastMethod = r.Method
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+			}
+			f.lastBody = map[string]any{}
+			if err := json.Unmarshal(body, &f.lastBody); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			// Minimal Key response.
+			fmt.Fprint(w, `{"applicationKeyId":"k","applicationKey":"s","accountId":"a","capabilities":[],"keyName":"n","expirationTimestamp":0}`)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+
+	b, err := AuthorizeAccount(context.Background(), "account-id", "application-key", SetAPIBase(f.srv.URL))
+	if err != nil {
+		t.Fatalf("AuthorizeAccount: %v", err)
+	}
+	f.b2 = b
+	return f
+}
+
+func (f *createKeyFixture) close() { f.srv.Close() }
+
+func TestCreateKeyUsesV3Endpoint(t *testing.T) {
+	f := newCreateKeyFixture(t)
+	defer f.close()
+
+	if _, err := f.b2.CreateKey(context.Background(), "keyname", []string{"readFiles"}, 0, "buck-single", "prefix/"); err != nil {
+		t.Fatalf("CreateKey: %v", err)
+	}
+	if want := "/b2api/v3/b2_create_key"; f.lastPath != want {
+		t.Errorf("path = %q, want %q", f.lastPath, want)
+	}
+	if f.lastMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", f.lastMethod)
+	}
+	if got, want := f.lastBody["bucketId"], "buck-single"; got != want {
+		t.Errorf("request body bucketId = %v, want %q", got, want)
+	}
+	if _, ok := f.lastBody["bucketIds"]; ok {
+		t.Errorf("request body unexpectedly contained bucketIds: %v", f.lastBody["bucketIds"])
+	}
+}
+
+func TestCreateKeyMultiBucketUsesV4Endpoint(t *testing.T) {
+	f := newCreateKeyFixture(t)
+	defer f.close()
+
+	if _, err := f.b2.CreateKeyMultiBucket(context.Background(), "keyname", []string{"readFiles"}, 0, []string{"buck-a", "buck-b"}, "prefix/"); err != nil {
+		t.Fatalf("CreateKeyMultiBucket: %v", err)
+	}
+	if want := "/b2api/v4/b2_create_key"; f.lastPath != want {
+		t.Errorf("path = %q, want %q", f.lastPath, want)
+	}
+	if f.lastMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", f.lastMethod)
+	}
+	got, ok := f.lastBody["bucketIds"].([]any)
+	if !ok {
+		t.Fatalf("request body bucketIds missing or wrong type: %v", f.lastBody["bucketIds"])
+	}
+	want := []any{"buck-a", "buck-b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("request body bucketIds = %v, want %v", got, want)
+	}
+	if _, ok := f.lastBody["bucketId"]; ok {
+		t.Errorf("request body unexpectedly contained bucketId: %v", f.lastBody["bucketId"])
+	}
+}

--- a/base/base_v4_test.go
+++ b/base/base_v4_test.go
@@ -29,24 +29,39 @@ import (
 // v4AuthJSON returns an authorizeAccount response body in the v4 shape.  The
 // apiUrl points back at the test server so follow-up calls (CreateKey, etc.)
 // hit the same handler.
+//
+// A restricted key's scope is nested under apiInfo.storageApi.allowed: buckets
+// is a list of {id, name} objects and namePrefix an optional string.  bucketIDs
+// and bucketNames are zipped into that list (they must be the same length).
+// When bucketIDs is empty the key is treated as unrestricted and allowed is
+// omitted entirely, matching B2's response for master keys.
 func v4AuthJSON(apiURL string, bucketIDs, bucketNames []string, namePrefix string) string {
+	storageAPI := map[string]any{
+		"absoluteMinimumPartSize": 5000000,
+		"apiUrl":                  apiURL,
+		"capabilities":            []string{"readFiles", "writeFiles"},
+		"downloadUrl":             apiURL,
+		"storageApi":              "storage",
+		"recommendedPartSize":     100000000,
+		"s3ApiUrl":                apiURL,
+	}
+	if len(bucketIDs) > 0 || namePrefix != "" {
+		buckets := make([]map[string]any, len(bucketIDs))
+		for i, id := range bucketIDs {
+			buckets[i] = map[string]any{"id": id, "name": bucketNames[i]}
+		}
+		storageAPI["allowed"] = map[string]any{
+			"buckets":      buckets,
+			"capabilities": []string{"readFiles", "writeFiles"},
+			"namePrefix":   namePrefix,
+		}
+	}
 	resp := map[string]any{
 		"accountId":                         "account-id",
 		"authorizationToken":                "auth-token",
 		"applicationKeyExpirationTimestamp": 0,
 		"apiInfo": map[string]any{
-			"storageApi": map[string]any{
-				"absoluteMinimumPartSize": 5000000,
-				"apiUrl":                  apiURL,
-				"bucketIds":               bucketIDs,
-				"bucketNames":             bucketNames,
-				"capabilities":            []string{"readFiles", "writeFiles"},
-				"downloadUrl":             apiURL,
-				"storageApi":              "storage",
-				"namePrefix":              namePrefix,
-				"recommendedPartSize":     100000000,
-				"s3ApiUrl":                apiURL,
-			},
+			"storageApi": storageAPI,
 		},
 	}
 	b, err := json.Marshal(resp)
@@ -106,6 +121,66 @@ func TestAuthorizeAccountV4UnrestrictedKey(t *testing.T) {
 	}
 	if b.pfx != "" {
 		t.Errorf("pfx = %q, want empty", b.pfx)
+	}
+}
+
+// TestAuthorizeAccountV4ReadsAllowedNesting guards against regressing to the v3
+// shape, where the key's scope sat at the storageApi top level.  In v4 the scope
+// lives under storageApi.allowed; a response with top-level bucketIds/namePrefix
+// (and an empty allowed) must yield no restrictions.
+func TestAuthorizeAccountV4ReadsAllowedNesting(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Deliberately place scope at the (wrong) v3 top level and leave
+		// allowed absent.  A correct v4 parser ignores these.
+		resp := map[string]any{
+			"accountId":          "account-id",
+			"authorizationToken": "auth-token",
+			"apiInfo": map[string]any{
+				"storageApi": map[string]any{
+					"apiUrl":      srv.URL,
+					"downloadUrl": srv.URL,
+					"s3ApiUrl":    srv.URL,
+					// v3-style fields that v4 no longer emits:
+					"bucketIds":   []string{"buck-a"},
+					"bucketNames": []string{"name-a"},
+					"namePrefix":  "restic/",
+				},
+			},
+		}
+		b, _ := json.Marshal(resp)
+		fmt.Fprint(w, string(b))
+	}))
+	defer srv.Close()
+
+	b, err := AuthorizeAccount(context.Background(), "account-id", "application-key", SetAPIBase(srv.URL))
+	if err != nil {
+		t.Fatalf("AuthorizeAccount: %v", err)
+	}
+	if len(b.buckets) != 0 {
+		t.Errorf("buckets = %v, want empty (top-level bucketIds must be ignored in v4)", b.buckets)
+	}
+	if b.pfx != "" {
+		t.Errorf("pfx = %q, want empty (top-level namePrefix must be ignored in v4)", b.pfx)
+	}
+}
+
+// TestAuthorizeAccountV4SingleBucketRestrictedKey covers the headline regression:
+// a bucket-restricted key whose scope is nested under storageApi.allowed must be
+// surfaced so the client knows which bucket it may use.
+func TestAuthorizeAccountV4SingleBucketRestrictedKey(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, v4AuthJSON(srv.URL, []string{"buck-a"}, []string{"name-a"}, ""))
+	}))
+	defer srv.Close()
+
+	b, err := AuthorizeAccount(context.Background(), "account-id", "application-key", SetAPIBase(srv.URL))
+	if err != nil {
+		t.Fatalf("AuthorizeAccount: %v", err)
+	}
+	if want := []string{"buck-a"}; !reflect.DeepEqual(b.buckets, want) {
+		t.Errorf("buckets = %v, want %v", b.buckets, want)
 	}
 }
 

--- a/base/base_v4_test.go
+++ b/base/base_v4_test.go
@@ -174,6 +174,62 @@ func TestAuthorizeAccountV4SingleBucketRestrictedKey(t *testing.T) {
 	}
 }
 
+// TestListBucketsFansOutForMultiBucketKeys pins the fan-out: b2_list_buckets
+// rejects any unfiltered request from a restricted key with 401 and accepts at
+// most one bucketId filter, so a multi-bucket key must issue one filtered
+// request per allowed bucket and merge the results.
+func TestListBucketsFansOutForMultiBucketKeys(t *testing.T) {
+	bucketNames := map[string]string{"buck-a": "name-a", "buck-b": "name-b"}
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/b2api/v4/b2_authorize_account":
+			fmt.Fprint(w, v4AuthJSON(srv.URL, []string{"buck-a", "buck-b"}, []string{"name-a", "name-b"}, ""))
+		case strings.HasSuffix(r.URL.Path, "/b2_list_buckets"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read body: %v", err)
+			}
+			req := map[string]any{}
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			id, _ := req["bucketId"].(string)
+			if id == "" {
+				// Live B2 rejects unfiltered listing from restricted keys.
+				w.WriteHeader(http.StatusUnauthorized)
+				fmt.Fprint(w, `{"status": 401, "code": "unauthorized", "message": ""}`)
+				return
+			}
+			name, ok := bucketNames[id]
+			if !ok {
+				t.Errorf("filtered list for unexpected bucketId %q", id)
+			}
+			fmt.Fprintf(w, `{"buckets": [{"bucketId": %q, "bucketName": %q, "bucketType": "allPrivate"}]}`, id, name)
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	b, err := AuthorizeAccount(context.Background(), "account-id", "application-key", SetAPIBase(srv.URL))
+	if err != nil {
+		t.Fatalf("AuthorizeAccount: %v", err)
+	}
+	buckets, err := b.ListBuckets(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListBuckets: %v", err)
+	}
+	var names []string
+	for _, bucket := range buckets {
+		names = append(names, bucket.Name)
+	}
+	if want := []string{"name-a", "name-b"}; !reflect.DeepEqual(names, want) {
+		t.Errorf("ListBuckets = %v, want %v", names, want)
+	}
+}
+
 // createKeyFixture serves authorize_account, then captures the single
 // b2_create_key request (path, method, body) for the caller to inspect.
 type createKeyFixture struct {

--- a/internal/b2types/b2types.go
+++ b/internal/b2types/b2types.go
@@ -37,22 +37,20 @@ type StorageAPIInfo struct {
 	Type           string   `json:"storageApi"`
 	PartSize       int      `json:"recommendedPartSize"`
 	S3URI          string   `json:"s3ApiUrl"`
-	// Allowed carries the key's scope (bucket and prefix restrictions). In the
-	// v4 authorize-account response it is nil/empty for unrestricted (master)
-	// keys and populated for bucket- or prefix-restricted keys.
+	// Allowed holds the key's scope; nil for unrestricted (master) keys.
 	Allowed *Allowed `json:"allowed"`
 }
 
-// Allowed is the scope of the application key used to authorize, as returned
-// under apiInfo.storageApi.allowed by b2_authorize_account in the v4 API.
+// Allowed is the authorizing key's scope, from apiInfo.storageApi.allowed in
+// the v4 b2_authorize_account response.
 type Allowed struct {
 	Buckets      []AllowedBucket `json:"buckets"`
 	Capabilities []string        `json:"capabilities"`
 	Prefix       string          `json:"namePrefix"`
 }
 
-// AllowedBucket is a single bucket a key is restricted to. Name may be empty if
-// the bucket no longer exists or the key lacks listBuckets.
+// AllowedBucket is a bucket a key is restricted to. Name is empty if the bucket
+// no longer exists or the key lacks listBuckets.
 type AllowedBucket struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -304,9 +302,7 @@ type ListUnfinishedLargeFilesResponse struct {
 	Continuation string                `json:"nextFileId"`
 }
 
-// CreateKeyRequestV3 is the b2_create_key request body for the v3 endpoint,
-// which accepts only a single bucket restriction and produces a legacy
-// single-bucket application key.
+// CreateKeyRequestV3 is the v3 b2_create_key body: a single bucket restriction.
 type CreateKeyRequestV3 struct {
 	AccountID    string   `json:"accountId"`
 	Capabilities []string `json:"capabilities"`
@@ -316,9 +312,7 @@ type CreateKeyRequestV3 struct {
 	Prefix       string   `json:"namePrefix,omitempty"`
 }
 
-// CreateKeyRequestV4 is the b2_create_key request body for the v4 endpoint,
-// which takes a list of bucket IDs and produces a Multi-Bucket Application
-// Key.
+// CreateKeyRequestV4 is the v4 b2_create_key body: a list of bucket IDs.
 type CreateKeyRequestV4 struct {
 	AccountID    string   `json:"accountId"`
 	Capabilities []string `json:"capabilities"`
@@ -328,11 +322,9 @@ type CreateKeyRequestV4 struct {
 	Prefix       string   `json:"namePrefix,omitempty"`
 }
 
-// Key is the response body for b2_create_key, b2_list_keys, and
-// b2_delete_key across both API versions.  The v3 endpoint returns a
-// singular bucketId; v4 returns a bucketIds array for Multi-Bucket
-// Application Keys.  Both tagged fields are present so this one struct
-// can decode either shape; exactly one will be populated per response.
+// Key is the b2_create_key/b2_list_keys/b2_delete_key response for both API
+// versions: v3 returns a singular bucketId, v4 a bucketIds array. Both tags are
+// present so one struct decodes either; exactly one is populated per response.
 type Key struct {
 	ID           string   `json:"applicationKeyId"`
 	Secret       string   `json:"applicationKey"`

--- a/internal/b2types/b2types.go
+++ b/internal/b2types/b2types.go
@@ -50,8 +50,8 @@ type Allowed struct {
 	Prefix       string          `json:"namePrefix"`
 }
 
-// AllowedBucket is a bucket a key is restricted to. Name is empty if the bucket
-// no longer exists or the key lacks listBuckets.
+// AllowedBucket is a bucket a key is restricted to. Name is empty only if the
+// bucket no longer exists.
 type AllowedBucket struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`

--- a/internal/b2types/b2types.go
+++ b/internal/b2types/b2types.go
@@ -37,7 +37,8 @@ type StorageAPIInfo struct {
 	Type           string   `json:"storageApi"`
 	PartSize       int      `json:"recommendedPartSize"`
 	S3URI          string   `json:"s3ApiUrl"`
-	// Allowed holds the key's scope; nil for unrestricted (master) keys.
+	// Allowed holds the key's scope. Master keys carry an Allowed whose
+	// Buckets and Prefix are null rather than omitting the field.
 	Allowed *Allowed `json:"allowed"`
 }
 

--- a/internal/b2types/b2types.go
+++ b/internal/b2types/b2types.go
@@ -32,14 +32,30 @@ type ErrorMessage struct {
 type StorageAPIInfo struct {
 	AbsMinPartSize int      `json:"absoluteMinimumPartSize"`
 	URI            string   `json:"apiUrl"`
-	BucketIDs      []string `json:"bucketIds"`
-	BucketNames    []string `json:"bucketNames"`
 	Capabilities   []string `json:"capabilities"`
 	DownloadURI    string   `json:"downloadUrl"`
 	Type           string   `json:"storageApi"`
-	Prefix         string   `json:"namePrefix"`
 	PartSize       int      `json:"recommendedPartSize"`
 	S3URI          string   `json:"s3ApiUrl"`
+	// Allowed carries the key's scope (bucket and prefix restrictions). In the
+	// v4 authorize-account response it is nil/empty for unrestricted (master)
+	// keys and populated for bucket- or prefix-restricted keys.
+	Allowed *Allowed `json:"allowed"`
+}
+
+// Allowed is the scope of the application key used to authorize, as returned
+// under apiInfo.storageApi.allowed by b2_authorize_account in the v4 API.
+type Allowed struct {
+	Buckets      []AllowedBucket `json:"buckets"`
+	Capabilities []string        `json:"capabilities"`
+	Prefix       string          `json:"namePrefix"`
+}
+
+// AllowedBucket is a single bucket a key is restricted to. Name may be empty if
+// the bucket no longer exists or the key lacks listBuckets.
+type AllowedBucket struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 type GroupsAPIInfo struct {

--- a/internal/b2types/b2types.go
+++ b/internal/b2types/b2types.go
@@ -20,6 +20,7 @@ package b2types
 
 const (
 	V3api = "/b2api/v3/"
+	V4api = "/b2api/v4/"
 )
 
 type ErrorMessage struct {
@@ -31,8 +32,8 @@ type ErrorMessage struct {
 type StorageAPIInfo struct {
 	AbsMinPartSize int      `json:"absoluteMinimumPartSize"`
 	URI            string   `json:"apiUrl"`
-	Bucket         string   `json:"bucketId"`
-	Name           string   `json:"bucketName"`
+	BucketIDs      []string `json:"bucketIds"`
+	BucketNames    []string `json:"bucketNames"`
 	Capabilities   []string `json:"capabilities"`
 	DownloadURI    string   `json:"downloadUrl"`
 	Type           string   `json:"storageApi"`
@@ -287,7 +288,10 @@ type ListUnfinishedLargeFilesResponse struct {
 	Continuation string                `json:"nextFileId"`
 }
 
-type CreateKeyRequest struct {
+// CreateKeyRequestV3 is the b2_create_key request body for the v3 endpoint,
+// which accepts only a single bucket restriction and produces a legacy
+// single-bucket application key.
+type CreateKeyRequestV3 struct {
 	AccountID    string   `json:"accountId"`
 	Capabilities []string `json:"capabilities"`
 	Name         string   `json:"keyName"`
@@ -296,6 +300,23 @@ type CreateKeyRequest struct {
 	Prefix       string   `json:"namePrefix,omitempty"`
 }
 
+// CreateKeyRequestV4 is the b2_create_key request body for the v4 endpoint,
+// which takes a list of bucket IDs and produces a Multi-Bucket Application
+// Key.
+type CreateKeyRequestV4 struct {
+	AccountID    string   `json:"accountId"`
+	Capabilities []string `json:"capabilities"`
+	Name         string   `json:"keyName"`
+	Valid        int      `json:"validDurationInSeconds,omitempty"`
+	BucketIDs    []string `json:"bucketIds,omitempty"`
+	Prefix       string   `json:"namePrefix,omitempty"`
+}
+
+// Key is the response body for b2_create_key, b2_list_keys, and
+// b2_delete_key across both API versions.  The v3 endpoint returns a
+// singular bucketId; v4 returns a bucketIds array for Multi-Bucket
+// Application Keys.  Both tagged fields are present so this one struct
+// can decode either shape; exactly one will be populated per response.
 type Key struct {
 	ID           string   `json:"applicationKeyId"`
 	Secret       string   `json:"applicationKey"`
@@ -303,7 +324,8 @@ type Key struct {
 	Capabilities []string `json:"capabilities"`
 	Name         string   `json:"keyName"`
 	Expires      int64    `json:"expirationTimestamp"`
-	BucketID     string   `json:"bucketId"`
+	BucketID     string   `json:"bucketId,omitempty"`
+	BucketIDs    []string `json:"bucketIds,omitempty"`
 	Prefix       string   `json:"namePrefix"`
 }
 


### PR DESCRIPTION
Fixes #27 with the ultimate goal of solving https://github.com/restic/restic/issues/5741

A new b2.CreateKeyMultiBucket was added to avoid breaking the type signature of b2.CreateKey, with support for multi-bucket application keys.

b2.CreateKey continues to use the old API (similar to the terraform provider's usage of `bucket_id` vs `bucket_ids`) in order to support clients which do not support multi-bucket application keys.

Client.CreateKey accepts a new BucketIDs option and selects CreateKeyMultiBucket when len(bucketIDs) > 1.

References:

- Backblaze release notes: https://www.backblaze.com/apidocs/b2-authorize-account
- `b2-sdk-python` PR #538 (the porting reference):<https://github.com/Backblaze/b2-sdk-python/pull/538
- `terraform-provider-b2` v0.12.1 (per-call v3/v4 dispatch): https://github.com/Backblaze/terraform-provider-b2/releases/tag/v0.12.1